### PR TITLE
Options for release level

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,18 @@ Basically it runs following tasks:
 
 `cargo release`
 
-### prerequisite
+### Prerequisite
 
 * Your project should be managed by git.
+
+### Release level
+
+Use `-l [level]` or `--level [level]` to specify a release level.
+
+* By default, cargo release removes prerelease extension (0.1.0-pre -> 0.1.0)
+* If level is `patch` and current version is a prerelease, it behaves like default; if current version has no extension, it bumps patch version (0.1.0 -> 0.1.1)
+* If level is `minor`, it bumps minor version (0.1.0-pre -> 0.2.0)
+* If level is `major`, it bumps major version (0.1.0-pre -> 1.0.0)
 
 ## License
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,29 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
         .unwrap();
 
     // STEP 2: Remove pre extension, save and commit
+    match args.value_of("level") {
+        Some(level) => {
+            match level {
+                "major" => {
+                    version.increment_major();
+                },
+                "minor" => {
+                    version.increment_minor();
+                },
+                "patch" => {
+                    version.increment_patch();
+                },
+                _ => {
+                    panic!("Invalid level: {}", level);
+                }
+            }
+        },
+        None => {
+            version.pre.clear();
+        }
+    }
+
+    //FIXME: support version bump level
     if version.is_prerelease() {
         version.pre.clear();
         let new_version_string = version.to_string();
@@ -107,6 +130,7 @@ fn main() {
         .author("Ning Sun <sunng@about.me>")
         .about("Cargo subcommand for you to smooth your release process.")
         .args_from_usage("
+        -l=[level] 'Release level: bumpping major|minor|patch version on release or removing prerelease extensions by default'
         [dry-run]... --dry-run 'Donot actually change anything.'")
         .get_matches();
 


### PR DESCRIPTION
Fixes #3 

Added option for release level, you can use `-l` to bump version on `cargo release`. 

* by default, `cargo release` removes prerelease extension (0.1.0-pre -> 0.1.0)
* if `level` is `patch` and current version is a prerelease, it behaves like default; if current version has no extension, it bumps patch version (0.1.0 -> 0.1.1)
* if `level` is `minor`, it bumps minor version (0.1.0-pre -> 0.2.0)
* if `level` is `major`, it bumps major version (0.1.0-pre -> 1.0.0)

