### PR TITLE
(feat) auto rewrite cargo.lock

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,8 +47,8 @@ pub fn save_cargo_config(config: &Table) -> Result<(), FatalError> {
 }
 
 pub fn rewrite_cargo_version(version: &str) -> Result<(), FatalError> {
+    let section_matcher = Regex::new("^\\[.+\\]").unwrap();
     {
-        let section_matcher = Regex::new("^\\[.+\\]").unwrap();
         let file_in = try!(File::open("Cargo.toml").map_err(FatalError::from));
         let mut bufreader = BufReader::new(file_in);
         let mut line = String::new();
@@ -74,9 +74,36 @@ pub fn rewrite_cargo_version(version: &str) -> Result<(), FatalError> {
             line.clear();
         }
     }
-
     try!(fs::rename("Cargo.toml.work", "Cargo.toml"));
 
+    {
+        let file_in = try!(File::open("Cargo.lock").map_err(FatalError::from));
+        let mut bufreader = BufReader::new(file_in);
+        let mut line = String::new();
+
+        let mut file_out = try!(File::create("Cargo.lock.work").map_err(FatalError::from));
+        let mut in_package = false;
+
+        loop {
+            let b = try!(bufreader.read_line(&mut line).map_err(FatalError::from));
+            if b <= 0 {
+                break;
+            }
+
+            if section_matcher.is_match(&line) {
+                in_package = line.trim() == "[root]";
+            }
+
+            if in_package && line.starts_with("version") {
+                line = format!("version = \"{}\"\n", version);
+            }
+
+            try!(file_out.write_all(line.as_bytes()).map_err(FatalError::from));
+            line.clear();
+        }
+    }
+
+    try!(fs::rename("Cargo.lock.work", "Cargo.lock"));
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,6 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
         let new_version_string = version.to_string();
         if !dry_run {
             try!(config::rewrite_cargo_version(&new_version_string));
-            // sync Cargo.toml and Cargo.lock
-            try!(cargo::update());
         }
 
         let commit_msg = format!("(cargo-release) version {}", new_version_string);
@@ -81,7 +79,6 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
     let updated_version_string = version.to_string();
     if !dry_run {
         try!(config::rewrite_cargo_version(&updated_version_string));
-        try!(cargo::update());
     }
     let commit_msg = format!("(cargo-release) start next development cycle {}",
                              updated_version_string);


### PR DESCRIPTION
Rewrite cargo.lock along with cargo.toml. Do not rely on another `cargo update` to sync.