### PR TITLE
New option: no-dev-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ After release, the version in Cargo.toml will be incremented and have
 a pre-release extension added, defaulting to `pre`.
 
 You can specify a different extension by using the
-`--dev-version-ext <ext>` option.
+`--dev-version-ext <ext>` option. To disable version bump after
+release, use `--no-dev-version` option.
 
 ### Configuration in Cargo.toml
 
@@ -113,6 +114,7 @@ store these options. Available keys:
   variables: `{{version}}`, `{{prefix}}` (the tag prefix)
 * `doc-commit-message`: string, a commit message template for doc
   import.
+* `no-dev-version`: bool, disable version bump after release.
 
 ```toml
 [package.metadata.release]

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub static PUSH_REMOTE: &'static str = "push-remote";
 pub static DOC_BRANCH: &'static str = "doc-branch";
 pub static DISABLE_PUSH: &'static str = "disable-push";
 pub static DEV_VERSION_EXT: &'static str = "dev-version-ext";
+pub static NO_DEV_VERSION: &'static str = "no-dev-version";
 pub static PRE_RELEASE_COMMIT_MESSAGE: &'static str = "pre-release-commit-message";
 pub static PRO_RELEASE_COMMIT_MESSAGE: &'static str = "pro-release-commit-message";
 pub static TAG_MESSAGE: &'static str = "tag-message";

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
     }
 
     // STEP 6: bump version
-    if !version::is_pre_release(level) || !no_dev_version {
+    if !version::is_pre_release(level) && !no_dev_version {
         version.increment_patch();
         version.pre.push(Identifier::AlphaNumeric(dev_version_ext.to_owned()));
         println!("Starting next development iteration {}", version);

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,10 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
                                       .and_then(|f| f.as_str())
                               })
                               .unwrap_or("pre");
-
+    let no_dev_version = args.occurrences_of("no-dev-version") > 0 ||
+                         config::get_release_config(&cargo_file, config::NO_DEV_VERSION)
+                             .and_then(|f| f.as_bool())
+                             .unwrap_or(false);
     let pre_release_commit_msg = config::get_release_config(&cargo_file,
                                                             config::PRE_RELEASE_COMMIT_MESSAGE)
                                      .and_then(|f| f.as_str())
@@ -155,7 +158,7 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
     }
 
     // STEP 6: bump version
-    if !version::is_pre_release(level) {
+    if !version::is_pre_release(level) || !no_dev_version {
         version.increment_patch();
         version.pre.push(Identifier::AlphaNumeric(dev_version_ext.to_owned()));
         println!("Starting next development iteration {}", version);
@@ -189,7 +192,8 @@ static USAGE: &'static str = "-l, --level=[level] 'Release level: bumpping major
                              [skip-push]... --skip-push 'Do not run git push in the last step'
                              --doc-branch=[doc-branch] 'Git branch to push documentation on'
                              --tag-prefix=[tag-prefix] 'Prefix of git tag, note that this will override default prefix based on sub-directory'
-                             --dev-version-ext=[dev-version-ext] 'Pre-release identifier(s) to append to the next development version after release'";
+                             --dev-version-ext=[dev-version-ext] 'Pre-release identifier(s) to append to the next development version after release'
+                             [no-dev-version]... --no-dev-version 'Do not create dev version after release'";
 
 fn main() {
     let matches =


### PR DESCRIPTION
Fixes #21 

Added new option:
`--no-dev-version` will disable version bump after release. 
`no-dev-version` in Cargo.toml is also supported.