### PR TITLE
Custom version replacement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ quick-error = "1.1.0"
 regex = "0.2.1"
 clap = "2.22.1"
 
+[badges]
+travis-ci = { repository = "https://github.com/sunng87/cargo-release", branch="0.7.1" }
+
 [package.metadata.release]
 sign-commit = true
 #upload-doc = true
-pre-release-replacements = [ {file="README.md", search="Current release: [\\d\\.]+", replace="Current release: {{version}}"} ]
+pre-release-replacements = [ {file="README.md", search="Current release: [a-z0-9\\.]+", replace="Current release: {{version}}"} , {file ="Cargo.toml", search="branch=\"[a-z0-9\\.]+\"", replace="branch=\"{{version}}\""} ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ clap = "2.22.1"
 [package.metadata.release]
 sign-commit = true
 #upload-doc = true
+pre-release-replacements = [ {file="README.md", regex="Current release: (.+?)$"} ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ clap = "2.22.1"
 [package.metadata.release]
 sign-commit = true
 #upload-doc = true
-pre-release-replacements = [ {file="README.md", regex="Current release: (.+?)$"} ]
+pre-release-replacements = [ {file="README.md", search="Current release: [\\d\\.]+", replace="Current release: {{version}}"} ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Basically it runs following tasks:
 
 ## Install
 
+Current release: 0.7.1
+
 `cargo install cargo-release`
 
 ## Usage

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub static DEV_VERSION_EXT: &'static str = "dev-version-ext";
 pub static NO_DEV_VERSION: &'static str = "no-dev-version";
 pub static PRE_RELEASE_COMMIT_MESSAGE: &'static str = "pre-release-commit-message";
 pub static PRO_RELEASE_COMMIT_MESSAGE: &'static str = "pro-release-commit-message";
+pub static PRE_RELEASE_REPLACEMENTS: &'static str = "pre-release-replacements";
 pub static TAG_MESSAGE: &'static str = "tag-message";
 pub static DOC_COMMIT_MESSAGE: &'static str = "doc-commit-message";
 
@@ -62,6 +63,7 @@ pub fn verify_release_config(config: &Value) -> Option<Vec<&str>> {
                           NO_DEV_VERSION,
                           PRE_RELEASE_COMMIT_MESSAGE,
                           PRO_RELEASE_COMMIT_MESSAGE,
+                          PRE_RELEASE_REPLACEMENTS,
                           TAG_MESSAGE,
                           DOC_COMMIT_MESSAGE];
     if let Some(ref r) = config.get("package")

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use std::io::Error as IOError;
 use std::string::FromUtf8Error;
 use semver::SemVerError;
 use toml::de::Error;
+use regex::Error as RegexError;
 
 quick_error! {
     #[derive(Debug)]
@@ -35,6 +36,14 @@ quick_error! {
         UnsupportedPrereleaseVersionScheme {
             display("This version scheme is not supported by cargo-release.")
             description("This version scheme is not supported by cargo-release. Use format like `pre`, `dev` or `alpha.1` for prerelease symbol")
+        }
+        ReplacerConfigError {
+            display("Insuffient replacer config: file, search and replace are required.")
+            description("Insuffient replacer config: file, search and replace are required.")
+        }
+        ReplacerRegexError(err: RegexError) {
+            from()
+            cause(err)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,8 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
     let pro_release_commit_msg =
         config::get_release_config(&cargo_file, config::PRO_RELEASE_COMMIT_MESSAGE)
             .and_then(|f| f.as_str())
-            .unwrap_or("(cargo-release) start next development iteration {{version}}");
+        .unwrap_or("(cargo-release) start next development iteration {{version}}");
+    let pre_release_replacements = config::get_release_config(&cargo_file, config::PRE_RELEASE_REPLACEMENTS); 
     let tag_msg = config::get_release_config(&cargo_file, config::TAG_MESSAGE)
         .and_then(|f| f.as_str())
         .unwrap_or("(cargo-release) {{prefix}} version {{version}}");
@@ -104,6 +105,11 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
         let new_version_string = version.to_string();
         if !dry_run {
             try!(config::rewrite_cargo_version(&new_version_string));
+        }
+
+        if let Some(pre_rel_rep) = pre_release_replacements {
+            // try update version number in configured files
+            try!(replace::do_replace_versions(pre_rel_rep, &new_version_string, dry_run));
         }
 
         let commit_msg =

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod cmd;
 mod git;
 mod cargo;
 mod version;
+mod replace;
 
 fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
     let cargo_file = try!(config::parse_cargo_config());

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -28,15 +28,21 @@ pub fn do_replace_versions(replace_config: &Value,
     if let &Value::Array(ref v) = replace_config {
         for tbl in v {
             if let &Value::Table(ref t) = tbl {
-                let file = t.get("file").and_then(|v| v.as_str()).unwrap();
-                let pattern = t.get("search").and_then(|v| v.as_str()).unwrap();
-                let replace = t.get("replace").and_then(|v| v.as_str()).unwrap();
+                let file = try!(t.get("file")
+                                    .and_then(|v| v.as_str())
+                                    .ok_or(FatalError::ReplacerConfigError));
+                let pattern = try!(t.get("search")
+                                       .and_then(|v| v.as_str())
+                                       .ok_or(FatalError::ReplacerConfigError));
+                let replace = try!(t.get("replace")
+                                       .and_then(|v| v.as_str())
+                                       .ok_or(FatalError::ReplacerConfigError));
                 let replace_with_version = replace.replace("{{version}}", version);
                 let replacer = replace_with_version.as_str();
 
                 let data = try!(load_from_file(&Path::new(file)));
 
-                let r = Regex::new(pattern).unwrap();
+                let r = try!(Regex::new(pattern).map_err(FatalError::from));
                 let result = r.replace_all(&data, replacer);
 
                 if !dry_run {

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -1,0 +1,41 @@
+use std::io::prelude::*;
+use std::io;
+use std::fs::{self, File};
+use std::path::Path;
+
+use regex::Regex;
+use error::FatalError;
+use toml::Value;
+
+fn load_from_file(path: &Path) -> io::Result<String> {
+    let mut file = try!(File::open(path));
+    let mut s = String::new();
+    try!(file.read_to_string(&mut s));
+    Ok(s)
+}
+
+fn save_to_file(path: &Path, content: &str) -> io::Result<()> {
+    let mut file = try!(File::create(path));
+    try!(file.write_all(&content.as_bytes()));
+    Ok(())
+}
+
+pub fn do_replace_versions(replace_config: &Value, version: &str) -> Result<bool, FatalError> {
+
+    if let &Value::Array(ref v) = replace_config {
+        for tbl in v {
+            if let &Value::Table(ref t) = tbl {
+                let file = t.get("file").and_then(|v| v.as_str()).unwrap();
+                let pattern = t.get("regex").and_then(|v| v.as_str()).unwrap();
+
+                let data = try!(load_from_file(&Path::new(file)));
+
+                let r = Regex::new(pattern).unwrap();
+                let result = r.replace_all(&data, version);
+
+                try!(save_to_file(&Path::new(file), &result));
+            }
+        }
+    }
+    Ok(true)
+}


### PR DESCRIPTION
Fixes #23 

This patch allows you to replace custom files on release. For example, you can update README for adding new version number. 