### PR TITLE
Allow specifying the tag prefix in Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ store these options. Available keys:
   version.
 * `tag-message`: string, a message template for tag. Available
   variables: `{{version}}`, `{{prefix}}` (the tag prefix)
+* `tag-prefix`: string, prefix of git tag, note that this will
+  override default prefix based on sub-directory.
 * `doc-commit-message`: string, a commit message template for doc
   import.
 * `no-dev-version`: bool, disable version bump after release.

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub static PRE_RELEASE_COMMIT_MESSAGE: &'static str = "pre-release-commit-messag
 pub static PRO_RELEASE_COMMIT_MESSAGE: &'static str = "pro-release-commit-message";
 pub static PRE_RELEASE_REPLACEMENTS: &'static str = "pre-release-replacements";
 pub static TAG_MESSAGE: &'static str = "tag-message";
+pub static TAG_PREFIX: &'static str = "tag-prefix";
 pub static DOC_COMMIT_MESSAGE: &'static str = "doc-commit-message";
 
 fn load_from_file(path: &Path) -> io::Result<String> {
@@ -65,6 +66,7 @@ pub fn verify_release_config(config: &Value) -> Option<Vec<&str>> {
                           PRO_RELEASE_COMMIT_MESSAGE,
                           PRE_RELEASE_REPLACEMENTS,
                           TAG_MESSAGE,
+                          TAG_PREFIX,
                           DOC_COMMIT_MESSAGE];
     if let Some(ref r) = config.get("package")
            .and_then(|f| f.as_table())

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,11 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
     let rel_path = try!(cmd::relative_path_for(&root));
     let tag_prefix = args.value_of("tag-prefix")
         .map(|t| t.to_owned())
-        .or(rel_path.as_ref().map(|t| format!("{}-", t)));
+        .or_else(|| config::get_release_config(&cargo_file, config::TAG_PREFIX)
+            .and_then(|f| f.as_str())
+            .map(|f| f.to_string()))
+        .or_else(|| rel_path.as_ref().map(|t| format!("{}-", t)));
+
 
     let current_version = version.to_string();
     let tag_name =


### PR DESCRIPTION
This will only override the default tag prefix if `--tag-prefix` is not specified.

This should fix #37.