### PR TITLE
make publish crate optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Basically it runs following tasks:
 * Check if current working directory is git clean
 * Read version from Cargo.toml, remove pre-release extension, bump
   version and commit if necessary
-* Run `cargo publish`
+* Run `cargo publish` ([if not disabled](http://doc.crates.io/manifest.html#the-publish--field-optional))
 * Generate rustdoc and push to gh-pages optionally
 * Create a git tag for this version
 * Bump version for next development cycle
@@ -35,11 +35,11 @@ Current release: 0.9.0-beta.1
 Use `-l [level]` or `--level [level]` to specify a release level.
 
 * By default, cargo release removes pre-release extension; if there is
-no pre-release extension, the current version will be used (0.1.0-pre
--> 0.1.0, 0.1.0 -> 0.1.0)
+  no pre-release extension, the current version will be used (0.1.0-pre
+  -> 0.1.0, 0.1.0 -> 0.1.0)
 * If level is `patch` and current version is a pre-release, it behaves
-like default; if current version has no extension, it bumps patch
-version (0.1.0 -> 0.1.1)
+  like default; if current version has no extension, it bumps patch
+  version (0.1.0 -> 0.1.1)
 * If level is `minor`, it bumps minor version (0.1.0-pre -> 0.2.0)
 * If level is `major`, it bumps major version (0.1.0-pre -> 1.0.0)
 
@@ -196,7 +196,7 @@ Licensed under either of
 
  * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-at your option.
+  at your option.
 
 ### Contribution
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,11 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
         .and_then(|f| f.as_str())
         .unwrap_or("(cargo-release) generate docs");
     let no_confirm = args.occurrences_of("no-confirm") > 0;
+    let publish = cargo_file.get("package")
+            .and_then(|f| f.as_table())
+            .and_then(|f| f.get("publish"))
+            .and_then(|f| f.as_bool())
+            .unwrap_or(true);
 
     // STEP 0: Check if working directory is clean
     if !try!(git::status()) {
@@ -191,9 +196,11 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
     }
 
     // STEP 3: cargo publish
-    println!("{}", Green.paint("Running cargo publish"));
-    if !try!(cargo::publish(dry_run)) {
-        return Ok(103);
+    if publish {
+        println!("{}", Green.paint("Running cargo publish"));
+        if !try!(cargo::publish(dry_run)) {
+            return Ok(103);
+        }
     }
 
     // STEP 4: upload doc


### PR DESCRIPTION
The official manifest has a [key](http://doc.crates.io/manifest.html#the-publish--field-optional) for disable publishing. 

Currently `cargo release` will fail when `cargo publish` is executed and **publish = false**.

With my PR no extra option is added!