### PR TITLE
Check if Cargo.lock exists before try to adjust version upgrade

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -132,7 +132,7 @@ pub fn rewrite_cargo_version(version: &str) -> Result<(), FatalError> {
     }
     try!(fs::rename("Cargo.toml.work", "Cargo.toml"));
 
-    {
+    if Path::new("Cargo.lock").exists() {
         let file_in = try!(File::open("Cargo.lock").map_err(FatalError::from));
         let mut bufreader = BufReader::new(file_in);
         let mut line = String::new();
@@ -157,9 +157,10 @@ pub fn rewrite_cargo_version(version: &str) -> Result<(), FatalError> {
             try!(file_out.write_all(line.as_bytes()).map_err(FatalError::from));
             line.clear();
         }
+
+        try!(fs::rename("Cargo.lock.work", "Cargo.lock"));
     }
 
-    try!(fs::rename("Cargo.lock.work", "Cargo.lock"));
     Ok(())
 }
 


### PR DESCRIPTION
`cargo release` tries to update the version in the file **Cargo.lock**.
But **Cargo.lock** must not be present! 

From the official [guilde](http://doc.crates.io/guide.html#cargo.toml-vs-cargo.lock):
> If you’re building a library that other projects will depend on, put Cargo.lock in your .gitignore. If you’re building an executable like a command-line tool or an application, check Cargo.lock into git.

Currently if **Cargo.lock** is not present, e.g., after `git clone`, an error appears:
```shell
Update to version 0.14.3 and commit
Fatal: IOError
```
With this PR **Cargo.lock** will be touched only if present!
