### PR TITLE
pre-publish-hook

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub static PRE_RELEASE_COMMIT_MESSAGE: &'static str = "pre-release-commit-messag
 pub static PRO_RELEASE_COMMIT_MESSAGE: &'static str = "pro-release-commit-message";
 pub static PRE_RELEASE_REPLACEMENTS: &'static str = "pre-release-replacements";
 pub static PRE_RELEASE_HOOK: &'static str = "pre-release-hook";
+pub static PRE_PUBLISH_HOOK: &'static str = "pre-publish-hook";
 pub static TAG_MESSAGE: &'static str = "tag-message";
 pub static TAG_PREFIX: &'static str = "tag-prefix";
 pub static DOC_COMMIT_MESSAGE: &'static str = "doc-commit-message";
@@ -67,6 +68,7 @@ pub fn verify_release_config(config: &Value) -> Option<Vec<&str>> {
                           PRO_RELEASE_COMMIT_MESSAGE,
                           PRE_RELEASE_REPLACEMENTS,
                           PRE_RELEASE_HOOK,
+                          PRE_PUBLISH_HOOK,
                           TAG_MESSAGE,
                           TAG_PREFIX,
                           DOC_COMMIT_MESSAGE];


### PR DESCRIPTION
I want to `cargo publish` for inner crate like the following directory structure.

```
inner-crate/
inner-crate/Cargo.toml
Cargo.toml
```

If `pre-publish-hook` is supported, I can write like below.

```
pre-publish-hook           = ["sh", "-c", "if [ \"$DRY_RUN\" = \"false\" ]; then cd inner-crate; cargo publish; else echo \"cd inner-crate; cargo publish;\"; fi"]
pre-release-replacements   = [{ file = "inner-crate/Cargo.toml", search = "version = \"[a-z0-9\\.-]+\"", replace = "version = \"{{version}}\"" }]
```
