### PR TITLE
Level as index argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Current release: 0.9.0
 
 ## Usage
 
-`cargo release`
+`cargo release [level]`
 
 ### Prerequisite
 
@@ -32,7 +32,7 @@ Current release: 0.9.0
 
 ### Release level
 
-Use `-l [level]` or `--level [level]` to specify a release level.
+Release level is to tell cargo-release how to bump version.
 
 * By default, cargo release removes pre-release extension; if there is
   no pre-release extension, the current version will be used (0.1.0-pre

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,7 +325,7 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
     Ok(0)
 }
 
-static USAGE: &'static str = "<level> 'Release level:  bumpping major|minor|patch version on release or removing prerelease extensions by default'
+static USAGE: &'static str = "[level] 'Release level:  bumpping major|minor|patch version on release or removing prerelease extensions by default'
                              -c, --config=[config] 'Custom config file'
                              -m, --metadata=[metadata] 'Semver metadata'
                              [sign]... --sign 'Sign git commit and tag'

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,7 +325,7 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
     Ok(0)
 }
 
-static USAGE: &'static str = "-l, --level=[level] 'Release level: bumpping major|minor|patch version on release or removing prerelease extensions by default'
+static USAGE: &'static str = "<level> 'Release level:  bumpping major|minor|patch version on release or removing prerelease extensions by default'
                              -c, --config=[config] 'Custom config file'
                              -m, --metadata=[metadata] 'Semver metadata'
                              [sign]... --sign 'Sign git commit and tag'


### PR DESCRIPTION
Fixes #52 

The level argument is changed from `cargo release -l <level>` to `cargo release [level]`. 