### PR TITLE
Add the `{{prev_version}}` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,10 @@ directory, or `.release.toml` at your home directory. Available keys are:
   for example. The table contains three keys:
   * `file`: the file to search and replace
   * `search`: regex that matches string you want to replace
-  * `replace`: the replacement, use `{{version}}` for current version and `{{date}}` for the release date
+  * `replace`: the replacement string; you can use the following variables:
+    * `{{version}}`: the current (bumped) crate version
+    * `{{date}}`: the release date
+    * `{{prev_version}}`: the version before `cargo-relase` was executed (before any version bump)
 * `pre-release-hook`: provide a command to run before `cargo-release`
   commits version change
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
             // try update version number in configured files
             try!(replace::do_replace_versions(
                 pre_rel_rep,
+                &prev_version_string,
                 &new_version_string,
                 dry_run,
             ));

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -23,6 +23,7 @@ fn save_to_file(path: &Path, content: &str) -> io::Result<()> {
 
 pub fn do_replace_versions(
     replace_config: &Value,
+    prev_version: &str,
     version: &str,
     dry_run: bool,
 ) -> Result<bool, FatalError> {
@@ -39,12 +40,12 @@ pub fn do_replace_versions(
                 let replace = try!(t.get("replace").and_then(|v| v.as_str()).ok_or(
                     FatalError::ReplacerConfigError,
                 ));
-                let replace_string = replace.replace("{{version}}", version).replace(
-                    "{{date}}",
-                    &Local::now()
+                let replace_string = replace
+                    .replace("{{version}}", version)
+                    .replace("{{prev_version}}", prev_version)
+                    .replace("{{date}}", &Local::now()
                         .format("%Y-%m-%d")
-                        .to_string(),
-                );
+                        .to_string());
                 let replacer = replace_string.as_str();
 
                 let data = try!(load_from_file(&Path::new(file)));


### PR DESCRIPTION
It's replaced by the crate version before `cargo-release` changes it in any way (ie. the version read straight from the `Cargo.toml`).

This can be used, for example, to automatically create links to the diffs between two versions in a changelog.