### PR TITLE
config: add a "skip-publish" option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ pub static SIGN_COMMIT: &'static str = "sign-commit";
 pub static UPLOAD_DOC: &'static str = "upload-doc";
 pub static PUSH_REMOTE: &'static str = "push-remote";
 pub static DOC_BRANCH: &'static str = "doc-branch";
+pub static DISABLE_PUBLISH: &'static str = "disable-publish";
 pub static DISABLE_PUSH: &'static str = "disable-push";
 pub static DEV_VERSION_EXT: &'static str = "dev-version-ext";
 pub static NO_DEV_VERSION: &'static str = "no-dev-version";
@@ -112,6 +113,7 @@ pub fn verify_release_config(config: &Table) -> Option<Vec<&str>> {
         UPLOAD_DOC,
         PUSH_REMOTE,
         DOC_BRANCH,
+        DISABLE_PUBLISH,
         DISABLE_PUSH,
         DEV_VERSION_EXT,
         NO_DEV_VERSION,

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,11 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         config::DOC_BRANCH,
         "gh-pages",
     );
+    let skip_publish = get_bool_option(
+        args.skip_publish,
+        release_config.as_ref(),
+        config::DISABLE_PUBLISH,
+    );
     let skip_push = get_bool_option(
         args.skip_push,
         release_config.as_ref(),
@@ -140,7 +145,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         .and_then(|f| f.as_table())
         .and_then(|f| f.get("publish"))
         .and_then(|f| f.as_bool())
-        .unwrap_or(true);
+        .unwrap_or(!skip_publish);
     let metadata = args.metadata.as_ref();
 
     // STEP 0: Check if working directory is clean
@@ -338,6 +343,10 @@ struct ReleaseOpt {
     #[structopt(long = "push-remote")]
     /// Git remote to push
     push_remote: Option<String>,
+
+    #[structopt(long = "skip-publish")]
+    /// Do not run cargo publish on release
+    skip_publish: bool,
 
     #[structopt(long = "skip-push")]
     /// Do not run git push in the last step


### PR DESCRIPTION
This introduces a new configuration option "skip-publish", disabled
by default. It is similar to the "publish" parameter in Cargo.toml,
but can be toggled on invidual `cargo release` runs without changing
the manifest.