### PR TITLE
 refactor(config): Consolidate logic via serde 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,10 @@ dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -314,8 +315,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.9.15"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "structopt"
@@ -394,10 +408,10 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.3.2"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -493,7 +507,8 @@ dependencies = [
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
+"checksum serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "2e20fde37801e83c891a2dc4ebd3b81f0da4d1fb67a9e0a2a3b921e2536a58ee"
+"checksum serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "633e97856567e518b59ffb2ad7c7a4fd4c5d91d9c7f32dd38a27b2bf7e8114ea"
 "checksum structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3"
 "checksum structopt-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04"
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
@@ -502,7 +517,7 @@ dependencies = [
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum toml 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bd86ad9ebee246fdedd610e0f6d0587b754a3d81438db930a244d0480ed7878f"
+"checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/sunng87/cargo-release"
 readme = "README.md"
 
 [dependencies]
-toml = {version = "0.3.1", default-features = false}
+toml = {version = "0.4", default-features = false}
+serde = { version = "1.0", features = ["derive"] }
 semver = "0.6.0"
 quick-error = "1.1.0"
 regex = "0.2.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use dirs;
 use regex::Regex;
 use semver::Version;
 use toml::value::Table;
-use toml::{self, Value};
+use toml::Value;
 
 use error::FatalError;
 
@@ -139,15 +139,6 @@ pub fn verify_release_config(config: &Table) -> Option<Vec<&str>> {
     } else {
         Some(invalid_keys)
     }
-}
-
-pub fn save_cargo_config(config: &Value) -> Result<(), FatalError> {
-    let cargo_file_path = Path::new("Cargo.toml");
-
-    let serialized_data = toml::to_string(config).unwrap();
-
-    save_to_file(&cargo_file_path, &serialized_data).map_err(FatalError::from)?;
-    Ok(())
 }
 
 pub fn rewrite_cargo_version(version: &str) -> Result<(), FatalError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 extern crate chrono;
 extern crate termcolor;
+extern crate serde;
 #[macro_use]
 extern crate maplit;
 #[macro_use]
@@ -19,8 +20,6 @@ use chrono::prelude::Local;
 use replace::{do_file_replacements, replace_in, Replacements};
 use semver::Identifier;
 use structopt::StructOpt;
-use toml::value::Table;
-use toml::Value;
 
 mod cargo;
 mod cmd;
@@ -31,135 +30,46 @@ mod replace;
 mod shell;
 mod version;
 
-fn get_string_option(
-    cli: &Option<String>,
-    config_file: Option<&Table>,
-    config_file_key: &str,
-    default_value: &str,
-) -> String {
-    cli.clone()
-        .or_else(|| {
-            config::get_release_config(config_file, config_file_key)
-                .and_then(|f| f.as_str())
-                .map(|f| f.to_owned())
-        }).unwrap_or(default_value.to_owned())
-}
-
-fn get_bool_option(cli: bool, config_file: Option<&Table>, config_file_key: &str) -> bool {
-    cli || config::get_release_config(config_file, config_file_key)
-        .and_then(|f| f.as_bool())
-        .unwrap_or(false)
-}
-
-/// Takes a list in form `"a,b,d,e"` and returns a Vec: `["a", "b", "c", "d"]`
-fn get_list_option(
-    cli: &Option<Vec<String>>,
-    config_file: Option<&Table>,
-    config_file_key: &str,
-) -> Option<Vec<String>> {
-    cli.clone().or_else(|| {
-        config::get_release_config(config_file, config_file_key)
-            .and_then(|f| f.as_array())
-            .and_then(|a| {
-                Some(
-                    a.iter()
-                        .map(|i| String::from(i.as_str().unwrap()))
-                        .collect::<Vec<String>>(),
-                )
-            })
-    })
-}
-
 fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
     let cargo_file = config::parse_cargo_config()?;
     let custom_config_path_option = args.config.as_ref();
     // FIXME:
     let release_config = if let Some(custom_config_path) = custom_config_path_option {
         // when calling with -c option
-        config::get_release_config_table_from_file(Path::new(custom_config_path))?
+        config::get_config_from_file(Path::new(custom_config_path))?
     } else {
-        config::resolve_release_config_table(&cargo_file)?
-    };
+        config::resolve_config()?
+    }.unwrap_or_default();
 
     // step -1
-    if let Some(ref release_config_table) = release_config {
-        if let Some(invalid_keys) = config::verify_release_config(release_config_table) {
-            for i in invalid_keys {
-                shell::log_warn(&format!("Unknown config key \"{}\" found", i));
-            }
-            return Ok(109);
-        }
-    }
-
     let dry_run = args.dry_run;
     let level = args.level.as_ref();
-    let sign = get_bool_option(args.sign, release_config.as_ref(), config::SIGN_COMMIT);
-    let upload_doc = get_bool_option(args.upload_doc, release_config.as_ref(), config::UPLOAD_DOC);
-    let git_remote = get_string_option(
-        &args.push_remote,
-        release_config.as_ref(),
-        config::PUSH_REMOTE,
-        "origin",
-    );
-    let doc_branch = get_string_option(
-        &args.doc_branch,
-        release_config.as_ref(),
-        config::DOC_BRANCH,
-        "gh-pages",
-    );
-    let skip_publish = get_bool_option(
-        args.skip_publish,
-        release_config.as_ref(),
-        config::DISABLE_PUBLISH,
-    );
-    let skip_push = get_bool_option(
-        args.skip_push,
-        release_config.as_ref(),
-        config::DISABLE_PUSH,
-    );
-    let dev_version_ext = get_string_option(
-        &args.dev_version_ext,
-        release_config.as_ref(),
-        config::DEV_VERSION_EXT,
-        "alpha.0",
-    );
-    let no_dev_version = get_bool_option(
-        args.no_dev_version,
-        release_config.as_ref(),
-        config::NO_DEV_VERSION,
-    );
-    let pre_release_commit_msg =
-        config::get_release_config(release_config.as_ref(), config::PRE_RELEASE_COMMIT_MESSAGE)
-            .and_then(|f| f.as_str())
-            .unwrap_or("(cargo-release) version {{version}}");
-    let pro_release_commit_msg =
-        config::get_release_config(release_config.as_ref(), config::PRO_RELEASE_COMMIT_MESSAGE)
-            .and_then(|f| f.as_str())
-            .unwrap_or("(cargo-release) start next development iteration {{version}}");
-    let pre_release_replacements =
-        config::get_release_config(release_config.as_ref(), config::PRE_RELEASE_REPLACEMENTS);
-    let pre_release_hook = config::get_release_config(
-        release_config.as_ref(),
-        config::PRE_RELEASE_HOOK,
-    ).and_then(|h| match h {
-        &Value::String(ref s) => Some(vec![s.as_ref()]),
-        &Value::Array(ref a) => Some(
-            a.iter()
-                .map(|v| v.as_str())
-                .filter(|o| o.is_some())
-                .map(|s| s.unwrap())
-                .collect(),
-        ),
-        _ => None,
-    });
-    let tag_msg = config::get_release_config(release_config.as_ref(), config::TAG_MESSAGE)
-        .and_then(|f| f.as_str())
-        .unwrap_or("(cargo-release) {{crate_name}} version {{version}}");
-    let skip_tag = get_bool_option(args.skip_tag, release_config.as_ref(), config::DISABLE_TAG);
-    let doc_commit_msg =
-        config::get_release_config(release_config.as_ref(), config::DOC_COMMIT_MESSAGE)
-            .and_then(|f| f.as_str())
-            .unwrap_or("(cargo-release) generate docs");
+    let sign = args.sign || release_config.sign_commit;
+    let upload_doc = args.upload_doc || release_config.upload_doc;
+    let git_remote = args.push_remote
+        .as_ref()
+        .map(|s| s.as_str())
+        .unwrap_or_else(|| release_config.push_remote.as_str());
+    let doc_branch = args.doc_branch
+        .as_ref()
+        .map(|s| s.as_str())
+        .unwrap_or_else(|| release_config.doc_branch.as_str());
+    let skip_publish = args.skip_publish || release_config.disable_publish;
+    let skip_push = args.skip_push || release_config.disable_push;
+    let dev_version_ext = args.dev_version_ext
+        .as_ref()
+        .map(|s| s.as_str())
+        .unwrap_or_else(|| release_config.dev_version_ext.as_str());
+    let no_dev_version = args.no_dev_version || release_config.no_dev_version;
+    let pre_release_commit_msg = release_config.pre_release_commit_message.as_str();
+    let pro_release_commit_msg = release_config.pro_release_commit_message.as_str();
+    let pre_release_replacements = &release_config.pre_release_replacements;
+    let pre_release_hook = release_config.pre_release_hook
+        .as_ref()
+        .map(|h| h.args());
+    let tag_msg = release_config.tag_message.as_str();
+    let skip_tag = args.skip_tag || release_config.disable_tag;
+    let doc_commit_msg = release_config.doc_commit_message.as_str();
     let no_confirm = args.no_confirm;
     let publish = cargo_file
         .get("package")
@@ -168,20 +78,16 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         .and_then(|f| f.as_bool())
         .unwrap_or(!skip_publish);
     let metadata = args.metadata.as_ref();
-    let feature_list = get_list_option(
-        &if args.features.is_empty() {
-            None
-        } else {
+    let feature_list = {
+        if ! args.features.is_empty() {
             Some(args.features.clone())
-        },
-        release_config.as_ref(),
-        config::ENABLE_FEATURES,
-    );
-    let all_features = get_bool_option(
-        args.all_features,
-        release_config.as_ref(),
-        config::ENABLE_ALL_FEATURES,
-    );
+        } else if release_config.enable_features.is_empty() {
+            Some(release_config.enable_features.clone())
+        } else {
+            None
+        }
+    };
+    let all_features = args.all_features || release_config.enable_all_features;
 
     let features = if all_features {
         Features::All
@@ -244,9 +150,9 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
             config::rewrite_cargo_version(&new_version_string)?;
         }
 
-        if let Some(pre_rel_rep) = pre_release_replacements {
+        if ! pre_release_replacements.is_empty() {
             // try replacing text in configured files
-            do_file_replacements(pre_rel_rep, &replacements, dry_run)?;
+            do_file_replacements(pre_release_replacements, &replacements, dry_run)?;
         }
 
         // pre-release hook
@@ -306,10 +212,8 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         .tag_prefix
         .as_ref()
         .map(|s| s.as_str())
-        .or_else(|| {
-            config::get_release_config(release_config.as_ref(), config::TAG_PREFIX)
-                .and_then(|f| f.as_str())
-        }).unwrap_or_else(|| {
+        .or_else(|| release_config.tag_prefix.as_ref().map(|s| s.as_str()))
+        .unwrap_or_else(|| {
             // crate_name as default tag prefix for multi-crate project
             if !is_root {
                 "{{crate_name}}-"


### PR DESCRIPTION
Configuration is now defined in one place.

Future directions, left off to keep this change small:
- Change merging of args / config to prevent accidentally reading from a
  non-merged value.
- Accept a `--manifest-path` arg and make everything relative to that.
- Support calling `cargo-release` in a child directory.