### PR TITLE
 fix(cargo): Read CARGO on user's system 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_fs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "globwalk 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +82,8 @@ dependencies = [
 name = "cargo-release"
 version = "0.12.0-beta.1"
 dependencies = [
+ "assert_fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -80,6 +94,18 @@ dependencies = [
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -113,8 +139,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -125,6 +182,14 @@ dependencies = [
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -148,9 +213,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "globset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ignore 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "heck"
@@ -161,6 +260,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +290,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "maplit"
@@ -190,6 +319,11 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "num-integer"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +335,32 @@ dependencies = [
 name = "num-traits"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "predicates"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "float-cmp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -236,6 +396,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +434,62 @@ dependencies = [
 name = "rand_core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rdrand"
@@ -285,6 +528,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,9 +548,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-syntax"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ryu"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "same-file"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "scoped_threadpool"
@@ -308,6 +592,15 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -332,6 +625,21 @@ dependencies = [
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "serde_json"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "smallvec"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structopt"
@@ -372,6 +680,19 @@ dependencies = [
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -417,6 +738,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ucd-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +768,16 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "walkdir"
+version = "2.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +790,14 @@ dependencies = [
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -472,60 +816,98 @@ dependencies = [
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum assert_fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4ce6ba957da497523c08f8e0bd0f2e038d23ad6a3f7a391ed9d4afa9314838c0"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+"checksum cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "585784cac9b05c93a53b17a0b24a5cdd1dfdda5256f030e089b549d2390cc720"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
+"checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
+"checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum float-cmp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "134a8fa843d80a51a5b77d36d42bc2def9edcb0262c914861d08129fd1926600"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81f7f8eb465745ea9b02e2704612a9946a59fa40572086c6fd49d6ddcf30bf31"
+"checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
+"checksum globwalk 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89fa2e29859da05acd066bd45996f05c271b271d7ec4a781f909682328f65d25"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum ignore 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ad03ca67dc12474ecd91fdb94d758cbd20cb4e7a78ebe831df26a9b7511e1162"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum maplit 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "22593015b8df7747861c69c28acd32589fb96c1686369f3b661d12e409d4cf65"
 "checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2e0a1a39eab95caf4f5556da9289b9e68f0aafac901b2ce80daaf020d3b733a8"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum predicates 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa984b7cd021a0bf5315bcce4c4ae61d2a535db2a8d288fc7578638690a7b7c3"
+"checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+"checksum predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
 "checksum proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "38fddd23d98b2144d197c0eca5705632d4fe2667d14a6be5df8934f8d74f1978"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+"checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
+"checksum rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7c690732391ae0abafced5015ffb53656abfaec61b342290e5eb56b286a679d"
+"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+"checksum regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53ee8cfdddb2e0291adfb9f13d31d3bbe0a03c9a402c01b1e24188d86c35b24f"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+"checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
+"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+"checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "2e20fde37801e83c891a2dc4ebd3b81f0da4d1fb67a9e0a2a3b921e2536a58ee"
 "checksum serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "633e97856567e518b59ffb2ad7c7a4fd4c5d91d9c7f32dd38a27b2bf7e8114ea"
+"checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
+"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3"
 "checksum structopt-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04"
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+"checksum treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,9 @@ chrono = "0.4"
 dirs = "1.0"
 structopt = {version = "0.2.7", default-features = false}
 
+[dev-dependencies]
+assert_fs = "0.11"
+cargo_metadata = "0.7"
+
 [badges]
 travis-ci = { repository = "sunng87/cargo-release", branch="0.12.0-beta.1" }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fs::{self, File};
 use std::io;
 use std::io::prelude::*;
@@ -13,10 +14,11 @@ use error::FatalError;
 use Features;
 
 pub fn publish(dry_run: bool, manifest_path: &Path, features: Features) -> Result<bool, FatalError> {
+    let cargo = env::var("CARGO")?;
     match features {
         Features::None => call(
             vec![
-                env!("CARGO"),
+                &cargo,
                 "publish",
                 "--manifest-path",
                 manifest_path.to_str().unwrap(),
@@ -25,7 +27,7 @@ pub fn publish(dry_run: bool, manifest_path: &Path, features: Features) -> Resul
         ),
         Features::Selective(vec) => call(
             vec![
-                env!("CARGO"),
+                &cargo,
                 "publish",
                 "--features",
                 &vec.join(" "),
@@ -36,7 +38,7 @@ pub fn publish(dry_run: bool, manifest_path: &Path, features: Features) -> Resul
         ),
         Features::All => call(
             vec![
-                env!("CARGO"),
+                &cargo,
                 "publish",
                 "--all-features",
                 "--manifest-path",
@@ -48,8 +50,9 @@ pub fn publish(dry_run: bool, manifest_path: &Path, features: Features) -> Resul
 }
 
 pub fn doc(dry_run: bool, manifest_path: &Path) -> Result<bool, FatalError> {
+    let cargo = env::var("CARGO")?;
     call(vec![
-        env!("CARGO"),
+        &cargo,
         "doc",
         "--no-deps",
         "--manifest-path",

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -31,13 +31,18 @@ pub fn doc(dry_run: bool) -> Result<bool, FatalError> {
     call(vec![env!("CARGO"), "doc", "--no-deps"], dry_run)
 }
 
-pub fn rewrite_cargo_version(version: &str) -> Result<(), FatalError> {
+pub fn set_manifest_version(manifest_path: &Path, version: &str) -> Result<(), FatalError> {
+    let temp_manifest_path = manifest_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("Cargo.toml.work");
+
     {
-        let file_in = File::open("Cargo.toml").map_err(FatalError::from)?;
+        let file_in = File::open(manifest_path).map_err(FatalError::from)?;
         let mut bufreader = BufReader::new(file_in);
         let mut line = String::new();
 
-        let mut file_out = File::create("Cargo.toml.work").map_err(FatalError::from)?;
+        let mut file_out = File::create(&temp_manifest_path).map_err(FatalError::from)?;
 
         let section_matcher = Regex::new("^\\[.+\\]").unwrap();
 
@@ -63,55 +68,54 @@ pub fn rewrite_cargo_version(version: &str) -> Result<(), FatalError> {
             line.clear();
         }
     }
-    fs::rename("Cargo.toml.work", "Cargo.toml")?;
+    fs::rename(temp_manifest_path, manifest_path)?;
 
-    if Path::new("Cargo.lock").exists() {
-        {
-            let file_in = File::open("Cargo.lock").map_err(FatalError::from)?;
-            let mut bufreader = BufReader::new(file_in);
-            let mut line = String::new();
+    Ok(())
+}
 
-            let mut file_out = File::create("Cargo.lock.work").map_err(FatalError::from)?;
+pub fn set_lock_version(lock_path: &Path, crate_name: &str, version: &str) -> Result<(), FatalError> {
+    let temp_lock_path = lock_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("Cargo.lock.work");
 
-            let section_matcher = Regex::new("^\\[\\[.+\\]\\]").unwrap();
+    {
+        let file_in = File::open(lock_path).map_err(FatalError::from)?;
+        let mut bufreader = BufReader::new(file_in);
+        let mut line = String::new();
 
-            let config = parse_cargo_config()?;
-            let crate_name = config
-                .get("package")
-                .and_then(|f| f.as_table())
-                .and_then(|f| f.get("name"))
-                .and_then(|f| f.as_str())
-                .unwrap();
+        let mut file_out = File::create(&temp_lock_path).map_err(FatalError::from)?;
 
-            let mut in_package = false;
+        let section_matcher = Regex::new("^\\[\\[.+\\]\\]").unwrap();
 
-            loop {
-                let b = bufreader.read_line(&mut line).map_err(FatalError::from)?;
-                if b <= 0 {
-                    break;
-                }
+        let mut in_package = false;
 
-                if section_matcher.is_match(&line) {
-                    in_package = line.trim() == "[[package]]";
-                }
-
-                if in_package && line.starts_with("name") {
-                    in_package = line == format!("name = \"{}\"\n", crate_name);
-                }
-
-                if in_package && line.starts_with("version") {
-                    line = format!("version = \"{}\"\n", version);
-                }
-
-                file_out
-                    .write_all(line.as_bytes())
-                    .map_err(FatalError::from)?;
-                line.clear();
+        loop {
+            let b = bufreader.read_line(&mut line).map_err(FatalError::from)?;
+            if b <= 0 {
+                break;
             }
-        }
 
-        fs::rename("Cargo.lock.work", "Cargo.lock")?;
+            if section_matcher.is_match(&line) {
+                in_package = line.trim() == "[[package]]";
+            }
+
+            if in_package && line.starts_with("name") {
+                in_package = line == format!("name = \"{}\"\n", crate_name);
+            }
+
+            if in_package && line.starts_with("version") {
+                line = format!("version = \"{}\"\n", version);
+            }
+
+            file_out
+                .write_all(line.as_bytes())
+                .map_err(FatalError::from)?;
+            line.clear();
+        }
     }
+
+    fs::rename(temp_lock_path, lock_path)?;
 
     Ok(())
 }
@@ -134,8 +138,39 @@ fn load_from_file(path: &Path) -> io::Result<String> {
     Ok(s)
 }
 
+#[cfg(test)]
+mod test {
+    use super::*;
 
-#[test]
-fn test_parse_cargo_config() {
-    parse_cargo_config().unwrap();
+    use assert_fs::prelude::*;
+    use assert_fs;
+    use cargo_metadata;
+
+    #[test]
+    fn test_parse_cargo_config() {
+        parse_cargo_config().unwrap();
+    }
+
+    #[test]
+    fn test_set_manifest_version() {
+        let temp = assert_fs::TempDir::new().unwrap();
+        temp.copy_from("tests/fixtures/simple", &["*"]).unwrap();
+        let manifest_path = temp.child("Cargo.toml");
+
+        let meta = cargo_metadata::MetadataCommand::new()
+            .manifest_path(manifest_path.path())
+            .exec()
+            .unwrap();
+        assert_eq!(meta.packages[0].version.to_string(), "0.1.0");
+
+        set_manifest_version(manifest_path.path(), "2.0.0").unwrap();
+
+        let meta = cargo_metadata::MetadataCommand::new()
+            .manifest_path(manifest_path.path())
+            .exec()
+            .unwrap();
+        assert_eq!(meta.packages[0].version.to_string(), "2.0.0");
+
+        temp.close().unwrap();
+    }
 }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -12,19 +12,49 @@ use cmd::call;
 use error::FatalError;
 use Features;
 
-pub fn publish(dry_run: bool, features: Features) -> Result<bool, FatalError> {
+pub fn publish(dry_run: bool, manifest_path: &Path, features: Features) -> Result<bool, FatalError> {
     match features {
-        Features::None => call(vec![env!("CARGO"), "publish"], dry_run),
+        Features::None => call(
+            vec![
+                env!("CARGO"),
+                "publish",
+                "--manifest-path",
+                manifest_path.to_str().unwrap(),
+            ],
+            dry_run
+        ),
         Features::Selective(vec) => call(
-            vec![env!("CARGO"), "publish", "--features", &vec.join(" ")],
+            vec![
+                env!("CARGO"),
+                "publish",
+                "--features",
+                &vec.join(" "),
+                "--manifest-path",
+                manifest_path.to_str().unwrap(),
+            ],
             dry_run,
         ),
-        Features::All => call(vec![env!("CARGO"), "publish", "--all-features"], dry_run),
+        Features::All => call(
+            vec![
+                env!("CARGO"),
+                "publish",
+                "--all-features",
+                "--manifest-path",
+                manifest_path.to_str().unwrap(),
+            ],
+            dry_run,
+        ),
     }
 }
 
-pub fn doc(dry_run: bool) -> Result<bool, FatalError> {
-    call(vec![env!("CARGO"), "doc", "--no-deps"], dry_run)
+pub fn doc(dry_run: bool, manifest_path: &Path) -> Result<bool, FatalError> {
+    call(vec![
+        env!("CARGO"),
+        "doc",
+        "--no-deps",
+        "--manifest-path",
+        manifest_path.to_str().unwrap(),
+    ], dry_run)
 }
 
 pub fn set_manifest_version(manifest_path: &Path, version: &str) -> Result<(), FatalError> {

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -153,10 +153,8 @@ pub fn parse_version(version: &str) -> Result<Version, FatalError> {
     Version::parse(version).map_err(|e| FatalError::from(e))
 }
 
-pub fn parse_cargo_config() -> Result<Value, FatalError> {
-    let cargo_file_path = Path::new("Cargo.toml");
-
-    let cargo_file_content = load_from_file(&cargo_file_path).map_err(FatalError::from)?;
+pub fn parse_cargo_config(manifest_path: &Path) -> Result<Value, FatalError> {
+    let cargo_file_content = load_from_file(&manifest_path).map_err(FatalError::from)?;
     cargo_file_content.parse().map_err(FatalError::from)
 }
 
@@ -177,7 +175,7 @@ mod test {
 
     #[test]
     fn test_parse_cargo_config() {
-        parse_cargo_config().unwrap();
+        parse_cargo_config(Path::new("Cargo.toml")).unwrap();
     }
 
     #[test]

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,3 +1,13 @@
+use std::fs::{self, File};
+use std::io;
+use std::io::prelude::*;
+use std::io::BufReader;
+use std::path::Path;
+
+use regex::Regex;
+use semver::Version;
+use toml::Value;
+
 use cmd::call;
 use error::FatalError;
 use Features;
@@ -19,4 +29,113 @@ pub fn update(dry_run: bool) -> Result<bool, FatalError> {
 
 pub fn doc(dry_run: bool) -> Result<bool, FatalError> {
     call(vec![env!("CARGO"), "doc", "--no-deps"], dry_run)
+}
+
+pub fn rewrite_cargo_version(version: &str) -> Result<(), FatalError> {
+    {
+        let file_in = File::open("Cargo.toml").map_err(FatalError::from)?;
+        let mut bufreader = BufReader::new(file_in);
+        let mut line = String::new();
+
+        let mut file_out = File::create("Cargo.toml.work").map_err(FatalError::from)?;
+
+        let section_matcher = Regex::new("^\\[.+\\]").unwrap();
+
+        let mut in_package = false;
+
+        loop {
+            let b = bufreader.read_line(&mut line).map_err(FatalError::from)?;
+            if b <= 0 {
+                break;
+            }
+
+            if section_matcher.is_match(&line) {
+                in_package = line.trim() == "[package]";
+            }
+
+            if in_package && line.starts_with("version") {
+                line = format!("version = \"{}\"\n", version);
+            }
+
+            file_out
+                .write_all(line.as_bytes())
+                .map_err(FatalError::from)?;
+            line.clear();
+        }
+    }
+    fs::rename("Cargo.toml.work", "Cargo.toml")?;
+
+    if Path::new("Cargo.lock").exists() {
+        {
+            let file_in = File::open("Cargo.lock").map_err(FatalError::from)?;
+            let mut bufreader = BufReader::new(file_in);
+            let mut line = String::new();
+
+            let mut file_out = File::create("Cargo.lock.work").map_err(FatalError::from)?;
+
+            let section_matcher = Regex::new("^\\[\\[.+\\]\\]").unwrap();
+
+            let config = parse_cargo_config()?;
+            let crate_name = config
+                .get("package")
+                .and_then(|f| f.as_table())
+                .and_then(|f| f.get("name"))
+                .and_then(|f| f.as_str())
+                .unwrap();
+
+            let mut in_package = false;
+
+            loop {
+                let b = bufreader.read_line(&mut line).map_err(FatalError::from)?;
+                if b <= 0 {
+                    break;
+                }
+
+                if section_matcher.is_match(&line) {
+                    in_package = line.trim() == "[[package]]";
+                }
+
+                if in_package && line.starts_with("name") {
+                    in_package = line == format!("name = \"{}\"\n", crate_name);
+                }
+
+                if in_package && line.starts_with("version") {
+                    line = format!("version = \"{}\"\n", version);
+                }
+
+                file_out
+                    .write_all(line.as_bytes())
+                    .map_err(FatalError::from)?;
+                line.clear();
+            }
+        }
+
+        fs::rename("Cargo.lock.work", "Cargo.lock")?;
+    }
+
+    Ok(())
+}
+
+pub fn parse_version(version: &str) -> Result<Version, FatalError> {
+    Version::parse(version).map_err(|e| FatalError::from(e))
+}
+
+pub fn parse_cargo_config() -> Result<Value, FatalError> {
+    let cargo_file_path = Path::new("Cargo.toml");
+
+    let cargo_file_content = load_from_file(&cargo_file_path).map_err(FatalError::from)?;
+    cargo_file_content.parse().map_err(FatalError::from)
+}
+
+fn load_from_file(path: &Path) -> io::Result<String> {
+    let mut file = File::open(path)?;
+    let mut s = String::new();
+    file.read_to_string(&mut s)?;
+    Ok(s)
+}
+
+
+#[test]
+fn test_parse_cargo_config() {
+    parse_cargo_config().unwrap();
 }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -23,10 +23,6 @@ pub fn publish(dry_run: bool, features: Features) -> Result<bool, FatalError> {
     }
 }
 
-pub fn update(dry_run: bool) -> Result<bool, FatalError> {
-    call(vec![env!("CARGO"), "update"], dry_run)
-}
-
 pub fn doc(dry_run: bool) -> Result<bool, FatalError> {
     call(vec![env!("CARGO"), "doc", "--no-deps"], dry_run)
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -67,12 +67,3 @@ pub fn call_with_env(
 pub fn is_current_path(path: &Path) -> Result<bool, FatalError> {
     Ok(current_dir()? == path)
 }
-
-pub fn relative_path_for(root: &str) -> Result<Option<String>, FatalError> {
-    let pwd = current_dir()?.to_str().unwrap().to_owned();
-    if pwd.len() > root.len() {
-        Ok(Some(pwd[root.len()..].to_string()))
-    } else {
-        Ok(None)
-    }
-}

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,12 +107,6 @@ fn load_from_file(path: &Path) -> io::Result<String> {
     Ok(s)
 }
 
-fn save_to_file(path: &Path, content: &str) -> io::Result<()> {
-    let mut file = File::create(path)?;
-    file.write_all(&content.as_bytes())?;
-    Ok(())
-}
-
 pub fn get_config_from_manifest(manifest_path: &Path) -> Result<Option<Config>, FatalError> {
     if manifest_path.exists() {
         let m = load_from_file(manifest_path)

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,7 +136,7 @@ pub fn get_config_from_file(file_path: &Path) -> Result<Option<Config>, FatalErr
 /// 2. $(pwd)/Cargo.toml `package.metadata.release` (with deprecation warning)
 /// 3. $HOME/.release.toml
 ///
-pub fn resolve_config() -> Result<Option<Config>, FatalError> {
+pub fn resolve_config(manifest_path: &Path) -> Result<Option<Config>, FatalError> {
     // Project release file.
     let current_dir_config = get_config_from_file(Path::new("release.toml"))?;
     if let Some(cfg) = current_dir_config {
@@ -144,7 +144,7 @@ pub fn resolve_config() -> Result<Option<Config>, FatalError> {
     };
 
     // Crate manifest.
-    let current_dir_config = get_config_from_manifest(Path::new("Cargo.toml"))?;
+    let current_dir_config = get_config_from_manifest(manifest_path)?;
     if let Some(cfg) = current_dir_config {
         return Ok(Some(cfg));
     };
@@ -162,6 +162,6 @@ pub fn resolve_config() -> Result<Option<Config>, FatalError> {
 
 #[test]
 fn test_release_config() {
-    let release_config = resolve_config().unwrap().unwrap();
+    let release_config = resolve_config(Path::new("Cargo.toml")).unwrap().unwrap();
     assert!(release_config.sign_commit);
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,6 @@ use std::path::{PathBuf, Path};
 use dirs;
 use regex::Regex;
 use semver::Version;
-use toml::value::Table;
 use toml::{self, Value};
 use serde::{Deserialize, Serialize};
 
@@ -122,16 +121,6 @@ pub fn parse_cargo_config() -> Result<Value, FatalError> {
 
     let cargo_file_content = load_from_file(&cargo_file_path).map_err(FatalError::from)?;
     cargo_file_content.parse().map_err(FatalError::from)
-}
-
-fn get_release_config_table_from_cargo<'a>(cargo_config: &'a Value) -> Option<&'a Table> {
-    cargo_config
-        .get("package")
-        .and_then(|f| f.as_table())
-        .and_then(|f| f.get("metadata"))
-        .and_then(|f| f.as_table())
-        .and_then(|f| f.get("release"))
-        .and_then(|f| f.as_table())
 }
 
 pub fn get_config_from_manifest(manifest_path: &Path) -> Result<Option<Config>, FatalError> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use regex::Error as RegexError;
 use semver::SemVerError;
+use std::env::VarError as VarError;
 use std::io::Error as IOError;
 use std::string::FromUtf8Error;
 use toml::de::Error as TomlError;
@@ -52,6 +53,12 @@ quick_error! {
             cause(err)
             display("RegexError {}", err)
             description(err.description())
+        }
+        VarError(err: VarError) {
+            from()
+            cause(err)
+            description(err.description())
+            display("Environment Variable Error: {}", err)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,14 +37,14 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
     let manifest_path = Path::new("Cargo.toml");
     let lock_path = Path::new("Cargo.lock");
 
-    let cargo_file = cargo::parse_cargo_config()?;
+    let cargo_file = cargo::parse_cargo_config(manifest_path)?;
     let custom_config_path_option = args.config.as_ref();
     // FIXME:
     let release_config = if let Some(custom_config_path) = custom_config_path_option {
         // when calling with -c option
         config::get_config_from_file(Path::new(custom_config_path))?
     } else {
-        config::resolve_config()?
+        config::resolve_config(manifest_path)?
     }.unwrap_or_default();
 
     // step -1

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 extern crate chrono;
 extern crate termcolor;
 extern crate serde;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ mod shell;
 mod version;
 
 fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
-    let cargo_file = config::parse_cargo_config()?;
+    let cargo_file = cargo::parse_cargo_config()?;
     let custom_config_path_option = args.config.as_ref();
     // FIXME:
     let release_config = if let Some(custom_config_path) = custom_config_path_option {
@@ -112,7 +112,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         .and_then(|f| f.as_table())
         .and_then(|f| f.get("version"))
         .and_then(|f| f.as_str())
-        .and_then(|f| config::parse_version(f).ok())
+        .and_then(|f| cargo::parse_version(f).ok())
         .unwrap();
     let prev_version_string = version.to_string();
 
@@ -147,7 +147,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
             new_version_string
         ));
         if !dry_run {
-            config::rewrite_cargo_version(&new_version_string)?;
+            cargo::rewrite_cargo_version(&new_version_string)?;
         }
 
         if ! pre_release_replacements.is_empty() {
@@ -248,7 +248,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         let updated_version_string = version.to_string();
         replacements.insert("{{next_version}}", updated_version_string.clone());
         if !dry_run {
-            config::rewrite_cargo_version(&updated_version_string)?;
+            cargo::rewrite_cargo_version(&updated_version_string)?;
         }
         let commit_msg = replace_in(&pro_release_commit_msg, &replacements);
 

--- a/tests/fixtures/simple/Cargo.lock
+++ b/tests/fixtures/simple/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "simple"
+version = "0.1.0"
+

--- a/tests/fixtures/simple/Cargo.toml
+++ b/tests/fixtures/simple/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "simple"
+version = "0.1.0"
+authors = ["Ed Page <eopage@gmail.com>"]
+edition = "2015"
+
+[dependencies]

--- a/tests/fixtures/simple/src/main.rs
+++ b/tests/fixtures/simple/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
`env!` reads the variable at compile time but this is a variable we
should be reading on the end-user's system, not the system
`cargo-release` was built on.