### PR TITLE
refactor: Centralize cwd assumption

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::env::current_dir;
 use std::path::Path;
 use std::process::Command;
 
@@ -62,8 +61,4 @@ pub fn call_with_env(
     dry_run: bool,
 ) -> Result<bool, FatalError> {
     do_call(command, None, Some(envs), dry_run)
-}
-
-pub fn is_current_path(path: &Path) -> Result<bool, FatalError> {
-    Ok(current_dir()? == path)
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -7,13 +7,13 @@ use error::FatalError;
 
 fn do_call(
     command: Vec<&str>,
-    path: Option<&str>,
+    path: Option<&Path>,
     envs: Option<BTreeMap<&str, &str>>,
     dry_run: bool,
 ) -> Result<bool, FatalError> {
     if dry_run {
         if path.is_some() {
-            println!("cd {}", path.unwrap());
+            println!("cd {}", path.unwrap().display());
         }
         println!("{}", command.join(" "));
         if path.is_some() {
@@ -52,7 +52,7 @@ pub fn call(command: Vec<&str>, dry_run: bool) -> Result<bool, FatalError> {
     do_call(command, None, None, dry_run)
 }
 
-pub fn call_on_path(command: Vec<&str>, path: &str, dry_run: bool) -> Result<bool, FatalError> {
+pub fn call_on_path(command: Vec<&str>, path: &Path, dry_run: bool) -> Result<bool, FatalError> {
     do_call(command, Some(path), None, dry_run)
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,7 +107,7 @@ fn load_from_file(path: &Path) -> io::Result<String> {
     Ok(s)
 }
 
-pub fn get_config_from_manifest(manifest_path: &Path) -> Result<Option<Config>, FatalError> {
+fn get_config_from_manifest(manifest_path: &Path) -> Result<Option<Config>, FatalError> {
     if manifest_path.exists() {
         let m = load_from_file(manifest_path)
             .map_err(FatalError::from)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,7 +138,10 @@ pub fn get_config_from_file(file_path: &Path) -> Result<Option<Config>, FatalErr
 ///
 pub fn resolve_config(manifest_path: &Path) -> Result<Option<Config>, FatalError> {
     // Project release file.
-    let current_dir_config = get_config_from_file(Path::new("release.toml"))?;
+    let default_config = manifest_path.parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("release.toml");
+    let current_dir_config = get_config_from_file(&default_config)?;
     if let Some(cfg) = current_dir_config {
         return Ok(Some(cfg));
     };

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use semver::SemVerError;
 use std::env::VarError as VarError;
 use std::io::Error as IOError;
 use std::string::FromUtf8Error;
+use std::str::Utf8Error;
 use toml::de::Error as TomlError;
 use toml_edit::TomlError as TomlEditError;
 use cargo_metadata::Error as CargoMetaError;
@@ -42,6 +43,12 @@ quick_error! {
             from()
             cause(err)
             display("SemVerError {}", err)
+            description(err.description())
+        }
+        Utf8Error(err: Utf8Error) {
+            from()
+            cause(err)
+            display("Utf8Error {}", err)
             description(err.description())
         }
         FromUtf8Error(err: FromUtf8Error) {

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::process::Command;
 
 use cmd::{call, call_on_path};
@@ -12,7 +13,7 @@ pub fn status() -> Result<bool, FatalError> {
     Ok(output.status.success())
 }
 
-pub fn commit_all(dir: &str, msg: &str, sign: bool, dry_run: bool) -> Result<bool, FatalError> {
+pub fn commit_all(dir: &Path, msg: &str, sign: bool, dry_run: bool) -> Result<bool, FatalError> {
     call_on_path(
         vec!["git", "commit", if sign { "-S" } else { "" }, "-am", msg],
         dir,
@@ -64,16 +65,16 @@ pub fn origin_url() -> Result<String, FatalError> {
     String::from_utf8(output.stdout).map_err(FatalError::from)
 }
 
-pub fn init(dir: &str, dry_run: bool) -> Result<bool, FatalError> {
+pub fn init(dir: &Path, dry_run: bool) -> Result<bool, FatalError> {
     call_on_path(vec!["git", "init"], dir, dry_run)
 }
 
-pub fn add_all(dir: &str, dry_run: bool) -> Result<bool, FatalError> {
+pub fn add_all(dir: &Path, dry_run: bool) -> Result<bool, FatalError> {
     call_on_path(vec!["git", "add", "."], dir, dry_run)
 }
 
 pub fn force_push(
-    dir: &str,
+    dir: &Path,
     remote: &str,
     refspec: &str,
     dry_run: bool,

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
 use cmd::call_on_path;
@@ -46,16 +47,17 @@ pub fn push_tag(dir: &Path, remote: &str, tag: &str, dry_run: bool) -> Result<bo
     call_on_path(vec!["git", "push", remote, tag], dir, dry_run)
 }
 
-pub fn top_level(dir: &Path) -> Result<String, FatalError> {
+pub fn top_level(dir: &Path) -> Result<PathBuf, FatalError> {
     let output = Command::new("git")
         .arg("rev-parse")
         .arg("--show-toplevel")
         .current_dir(dir)
         .output()
         .map_err(FatalError::from)?;
-    String::from_utf8(output.stdout)
-        .map_err(FatalError::from)
-        .map(|s| s.trim_end().to_owned())
+    let path = std::str::from_utf8(&output.stdout)
+        .map_err(FatalError::from)?
+        .trim_end();
+    Ok(Path::new(path).to_owned())
 }
 
 pub fn origin_url(dir: &Path) -> Result<String, FatalError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
 
         if ! pre_release_replacements.is_empty() {
             // try replacing text in configured files
-            do_file_replacements(pre_release_replacements, &replacements, dry_run)?;
+            do_file_replacements(pre_release_replacements, &replacements, cwd, dry_run)?;
         }
 
         // pre-release hook

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ mod version;
 
 fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
     let manifest_path = Path::new("Cargo.toml");
+    let cwd = manifest_path.parent().unwrap_or_else(|| Path::new("."));
 
     let cargo_file = cargo::parse_cargo_config(manifest_path)?;
     let custom_config_path_option = args.config.as_ref();
@@ -106,7 +107,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
     };
 
     // STEP 0: Check if working directory is clean
-    if !git::status()? {
+    if !git::status(cwd)? {
         shell::log_warn("Uncommitted changes detected, please commit before release.");
         if !dry_run {
             return Ok(101);
@@ -180,7 +181,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         }
 
         let commit_msg = replace_in(&pre_release_commit_msg, &replacements);
-        if !git::commit_all(Path::new("."), &commit_msg, sign, dry_run)? {
+        if !git::commit_all(cwd, &commit_msg, sign, dry_run)? {
             // commit failed, abort release
             return Ok(102);
         }
@@ -199,22 +200,22 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         shell::log_info("Building and exporting docs.");
         cargo::doc(dry_run, manifest_path)?;
 
-        let doc_path = Path::new("target/doc/");
+        let doc_path = cwd.join("target/doc/");
 
         shell::log_info("Commit and push docs.");
-        git::init(doc_path, dry_run)?;
-        git::add_all(doc_path, dry_run)?;
-        git::commit_all(doc_path, doc_commit_msg, sign, dry_run)?;
-        let default_remote = git::origin_url()?;
+        git::init(&doc_path, dry_run)?;
+        git::add_all(&doc_path, dry_run)?;
+        git::commit_all(&doc_path, doc_commit_msg, sign, dry_run)?;
+        let default_remote = git::origin_url(cwd)?;
 
         let mut refspec = String::from("master:");
         refspec.push_str(&doc_branch);
 
-        git::force_push(doc_path, default_remote.trim(), &refspec, dry_run)?;
+        git::force_push(&doc_path, default_remote.trim(), &refspec, dry_run)?;
     }
 
     // STEP 5: Tag
-    let root = git::top_level()?;
+    let root = git::top_level(cwd)?;
     let is_root = cmd::is_current_path(&Path::new(&root))?;
     let tag_prefix = args
         .tag_prefix
@@ -240,7 +241,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         let tag_message = replace_in(tag_msg, &replacements);
 
         shell::log_info(&format!("Creating git tag {}", tag_name));
-        if !git::tag(&tag_name, &tag_message, sign, dry_run)? {
+        if !git::tag(cwd, &tag_name, &tag_message, sign, dry_run)? {
             // tag failed, abort release
             return Ok(104);
         }
@@ -261,7 +262,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         }
         let commit_msg = replace_in(&pro_release_commit_msg, &replacements);
 
-        if !git::commit_all(Path::new("."), &commit_msg, sign, dry_run)? {
+        if !git::commit_all(cwd, &commit_msg, sign, dry_run)? {
             return Ok(105);
         }
     }
@@ -269,10 +270,10 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
     // STEP 7: git push
     if !skip_push {
         shell::log_info("Pushing to git remote");
-        if !git::push(&git_remote, dry_run)? {
+        if !git::push(cwd, &git_remote, dry_run)? {
             return Ok(106);
         }
-        if !skip_tag && !git::push_tag(&git_remote, &tag_name, dry_run)? {
+        if !skip_tag && !git::push_tag(cwd, &git_remote, &tag_name, dry_run)? {
             return Ok(106);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         }
 
         let commit_msg = replace_in(&pre_release_commit_msg, &replacements);
-        if !git::commit_all(".", &commit_msg, sign, dry_run)? {
+        if !git::commit_all(Path::new("."), &commit_msg, sign, dry_run)? {
             // commit failed, abort release
             return Ok(102);
         }
@@ -199,7 +199,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         shell::log_info("Building and exporting docs.");
         cargo::doc(dry_run, manifest_path)?;
 
-        let doc_path = "target/doc/";
+        let doc_path = Path::new("target/doc/");
 
         shell::log_info("Commit and push docs.");
         git::init(doc_path, dry_run)?;
@@ -261,7 +261,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         }
         let commit_msg = replace_in(&pro_release_commit_msg, &replacements);
 
-        if !git::commit_all(".", &commit_msg, sign, dry_run)? {
+        if !git::commit_all(Path::new("."), &commit_msg, sign, dry_run)? {
             return Ok(105);
         }
     }

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -33,22 +33,23 @@ pub fn replace_in(input: &str, r: &Replacements) -> String {
 pub fn do_file_replacements(
     replace_config: &[Replace],
     replacements: &Replacements,
+    cwd: &Path,
     dry_run: bool,
 ) -> Result<bool, FatalError> {
     for replace in replace_config {
-        let file = replace.file.as_path();
+        let file = cwd.join(replace.file.as_path());
         let pattern = replace.search.as_str();
         let to_replace = replace.replace.as_str();
 
         let replacer = replace_in(to_replace, replacements);
 
-        let data = load_from_file(file)?;
+        let data = load_from_file(&file)?;
 
         let r = Regex::new(pattern).map_err(FatalError::from)?;
         let result = r.replace_all(&data, replacer.as_str());
 
         if !dry_run {
-            save_to_file(&Path::new(file), &result)?;
+            save_to_file(&file, &result)?;
         }
     }
     Ok(true)


### PR DESCRIPTION
This lays the ground work for either a `--manifest-path` flag or a `--all` flag (workspace support)