### PR TITLE
Check git availability before workflow

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -81,5 +81,9 @@ quick_error! {
             description(err.description())
             display("Environment Variable Error: {}", err)
         }
+        GitError {
+            description("git is not found")
+            display("git is not found. git is required for cargo-release workflow.")
+        }
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -87,3 +87,11 @@ pub fn force_push(
 ) -> Result<bool, FatalError> {
     call_on_path(vec!["git", "push", "-f", remote, refspec], dir, dry_run)
 }
+
+pub(crate) fn git_version() -> Result<(), FatalError> {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|_| ())
+        .map_err(|_| FatalError::GitError)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,9 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         }
     };
 
+    // STEP -1: Check if git is available
+    git::git_version()?;
+
     // STEP 0: Check if working directory is clean
     if !git::status(cwd)? {
         shell::log_warn("Uncommitted changes detected, please commit before release.");


### PR DESCRIPTION
Fixes #67, #92 

Run `git --version` explicitly to ensure git is installed