### PR TITLE
Port to cargo_metadata where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
  "predicates 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -622,14 +622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "semver"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -944,7 +936,6 @@ dependencies = [
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
-"checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "2e20fde37801e83c891a2dc4ebd3b81f0da4d1fb67a9e0a2a3b921e2536a58ee"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ cargo_metadata = "0.7"
 toml = {version = "0.4", default-features = false}
 toml_edit = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-semver = "0.6.0"
+semver = "0.9.0"
 quick-error = "1.1.0"
 regex = "0.2.1"
 termcolor = "0.3.6"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -5,7 +5,6 @@ use std::io::prelude::*;
 use std::path::Path;
 
 use cargo_metadata;
-use semver::Version;
 use toml::Value;
 use toml_edit;
 
@@ -91,10 +90,6 @@ pub fn update_lock(manifest_path: &Path) -> Result<(), FatalError> {
         .map_err(FatalError::from)?;
 
     Ok(())
-}
-
-pub fn parse_version(version: &str) -> Result<Version, FatalError> {
-    Version::parse(version).map_err(|e| FatalError::from(e))
 }
 
 pub fn parse_cargo_config(manifest_path: &Path) -> Result<Value, FatalError> {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -58,7 +58,8 @@ pub fn call_on_path(command: Vec<&str>, path: &Path, dry_run: bool) -> Result<bo
 pub fn call_with_env(
     command: Vec<&str>,
     envs: BTreeMap<&str, &str>,
+    path: &Path,
     dry_run: bool,
 ) -> Result<bool, FatalError> {
-    do_call(command, None, Some(envs), dry_run)
+    do_call(command, Some(path), Some(envs), dry_run)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,6 +57,10 @@ quick_error! {
             display("FromUtf8Error {}", err)
             description(err.description())
         }
+        NoPackage {
+            display("No package in manifest file")
+            description("No package in manifest file")
+        }
         InvalidReleaseLevel(level: String) {
             display("Unsupported release level {}", level)
             description("Unsupported release level, only major, minor and patch are supported")

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,7 +221,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         shell::log_info("Building and exporting docs.");
         cargo::doc(dry_run, &manifest_path)?;
 
-        let doc_path = cwd.join("target/doc/");
+        let doc_path = ws_meta.target_directory.join("doc");
 
         shell::log_info("Commit and push docs.");
         git::init(&doc_path, dry_run)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,21 +136,10 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
     }
 
     // STEP 1: Query a bunch of information for later use.
-    let mut version = cargo_file
-        .get("package")
-        .and_then(|f| f.as_table())
-        .and_then(|f| f.get("version"))
-        .and_then(|f| f.as_str())
-        .and_then(|f| cargo::parse_version(f).ok())
-        .unwrap();
+    let mut version = pkg_meta.version.clone();
     let prev_version_string = version.to_string();
 
-    let crate_name = cargo_file
-        .get("package")
-        .and_then(|f| f.as_table())
-        .and_then(|f| f.get("name"))
-        .and_then(|f| f.as_str())
-        .unwrap();
+    let crate_name = pkg_meta.name.as_str();
 
     let mut replacements = Replacements::new();
     replacements.insert("{{prev_version}}", prev_version_string.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
             };
             // we use dry_run environmental variable to run the script
             // so here we set dry_run=false and always execute the command.
-            if !cmd::call_with_env(pre_rel_hook, envs, false)? {
+            if !cmd::call_with_env(pre_rel_hook, envs, cwd, false)? {
                 shell::log_warn("Release aborted by non-zero return of prerelease hook.");
                 return Ok(107);
             }


### PR DESCRIPTION
For determining the default tag, I did not switch us from finding the git root to finding the workspace root.  I figured that if the crate wasn't in the git root, regardless of the use of workspaces, we probably want to scope the tag.