### PR TITLE
Update workspace dependents on release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver-parser 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -635,6 +636,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "semver-parser"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde"
 version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +944,7 @@ dependencies = [
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum semver-parser 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b46e1121e8180c12ff69a742aabc4f310542b6ccb69f1691689ac17fdf8618aa"
 "checksum serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "2e20fde37801e83c891a2dc4ebd3b81f0da4d1fb67a9e0a2a3b921e2536a58ee"
 "checksum serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "633e97856567e518b59ffb2ad7c7a4fd4c5d91d9c7f32dd38a27b2bf7e8114ea"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "assert_fs 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ toml = {version = "0.4", default-features = false}
 toml_edit = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 semver = "0.9.0"
+semver-parser = "0.9.0"
 quick-error = "1.1.0"
 regex = "0.2.1"
 termcolor = "0.3.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ maplit = "0.1.4"
 chrono = "0.4"
 dirs = "1.0"
 structopt = {version = "0.2.7", default-features = false}
+clap = { version = "2", default-features = false }
 
 [dev-dependencies]
 assert_fs = "0.11"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -63,7 +63,7 @@ pub fn doc(dry_run: bool, manifest_path: &Path) -> Result<bool, FatalError> {
     ], dry_run)
 }
 
-pub fn set_manifest_version(manifest_path: &Path, version: &str) -> Result<(), FatalError> {
+pub fn set_package_version(manifest_path: &Path, version: &str) -> Result<(), FatalError> {
     let temp_manifest_path = manifest_path
         .parent()
         .unwrap_or_else(|| Path::new("."))
@@ -118,7 +118,7 @@ mod test {
     }
 
     #[test]
-    fn test_set_manifest_version() {
+    fn test_set_package_version() {
         let temp = assert_fs::TempDir::new().unwrap();
         temp.copy_from("tests/fixtures/simple", &["*"]).unwrap();
         let manifest_path = temp.child("Cargo.toml");
@@ -129,7 +129,7 @@ mod test {
             .unwrap();
         assert_eq!(meta.packages[0].version.to_string(), "0.1.0");
 
-        set_manifest_version(manifest_path.path(), "2.0.0").unwrap();
+        set_package_version(manifest_path.path(), "2.0.0").unwrap();
 
         let meta = cargo_metadata::MetadataCommand::new()
             .manifest_path(manifest_path.path())
@@ -147,7 +147,7 @@ mod test {
         let manifest_path = temp.child("Cargo.toml");
         let lock_path = temp.child("Cargo.lock");
 
-        set_manifest_version(manifest_path.path(), "2.0.0").unwrap();
+        set_package_version(manifest_path.path(), "2.0.0").unwrap();
         lock_path.assert(predicate::path::eq_file(Path::new("tests/fixtures/simple/Cargo.lock")));
 
         update_lock(manifest_path.path()).unwrap();
@@ -163,7 +163,7 @@ mod test {
         let manifest_path = temp.child("b/Cargo.toml");
         let lock_path = temp.child("Cargo.lock");
 
-        set_manifest_version(manifest_path.path(), "2.0.0").unwrap();
+        set_package_version(manifest_path.path(), "2.0.0").unwrap();
         lock_path.assert(predicate::path::eq_file(Path::new("tests/fixtures/pure_ws/Cargo.lock")));
 
         update_lock(manifest_path.path()).unwrap();
@@ -179,7 +179,7 @@ mod test {
         let manifest_path = temp.child("Cargo.toml");
         let lock_path = temp.child("Cargo.lock");
 
-        set_manifest_version(manifest_path.path(), "2.0.0").unwrap();
+        set_package_version(manifest_path.path(), "2.0.0").unwrap();
         lock_path.assert(predicate::path::eq_file(Path::new("tests/fixtures/mixed_ws/Cargo.lock")));
 
         update_lock(manifest_path.path()).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -163,8 +163,17 @@ pub fn resolve_config(manifest_path: &Path) -> Result<Option<Config>, FatalError
     Ok(None)
 }
 
-#[test]
-fn test_release_config() {
-    let release_config = resolve_config(Path::new("Cargo.toml")).unwrap().unwrap();
-    assert!(release_config.sign_commit);
+#[cfg(test)]
+mod test{
+    use super::*;
+
+    mod resolve_config {
+        use super::*;
+
+        #[test]
+        fn doesnt_panic() {
+            let release_config = resolve_config(Path::new("Cargo.toml")).unwrap().unwrap();
+            assert!(release_config.sign_commit);
+        }
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub disable_tag: bool,
     pub enable_features: Vec<String>,
     pub enable_all_features: bool,
+    pub dependent_version: DependentVersion,
 }
 
 impl Default for Config {
@@ -54,6 +55,7 @@ impl Default for Config {
             disable_tag: false,
             enable_features: vec![],
             enable_all_features: false,
+            dependent_version: Default::default(),
         }
     }
 }
@@ -79,6 +81,24 @@ impl Command {
             Command::Line(ref s) => vec![s.as_str()],
             Command::Args(ref a) => a.iter().map(|s| s.as_str()).collect(),
         }
+    }
+}
+
+arg_enum! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(rename_all = "kebab-case")]
+    pub enum DependentVersion {
+        Upgrade,
+        Fix,
+        Error,
+        Warn,
+        Ignore,
+    }
+}
+
+impl Default for DependentVersion {
+    fn default() -> Self {
+        DependentVersion::Fix
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,6 +69,10 @@ quick_error! {
             display("This version scheme is not supported by cargo-release.")
             description("This version scheme is not supported by cargo-release. Use format like `pre`, `dev` or `alpha.1` for prerelease symbol")
         }
+        UnsupportedVersionReq(req: String) {
+            display("Support for modifying {} is currently unsupported", req)
+            description("Support for modifying this version req is currently unsupported.")
+        }
         ReplacerConfigError {
             display("Insuffient replacer config: file, search and replace are required.")
             description("Insuffient replacer config: file, search and replace are required.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,19 +216,23 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
                 config::DependentVersion::Fix => {
                     if ! dep.req.matches(&version) {
                         let new_req = version::set_requirement(&dep.req, &version)?;
-                        if dry_run {
-                            println!("Fixing {}'s dependency on {} to `{}` (from `{}`)", pkg.name, pkg_meta.name, new_req, dep.req);
-                        } else {
-                            cargo::set_dependency_version(&pkg.manifest_path, &pkg_meta.name, &new_req)?;
+                        if let Some(new_req) = new_req {
+                            if dry_run {
+                                println!("Fixing {}'s dependency on {} to `{}` (from `{}`)", pkg.name, pkg_meta.name, new_req, dep.req);
+                            } else {
+                                cargo::set_dependency_version(&pkg.manifest_path, &pkg_meta.name, &new_req)?;
+                            }
                         }
                     }
                 },
                 config::DependentVersion::Upgrade => {
                     let new_req = version::set_requirement(&dep.req, &version)?;
-                    if dry_run {
-                        println!("Upgrading {}'s dependency on {} to `{}` (from `{}`)", pkg.name, pkg_meta.name, new_req, dep.req);
-                    } else {
-                        cargo::set_dependency_version(&pkg.manifest_path, &pkg_meta.name, &new_req)?;
+                    if let Some(new_req) = new_req {
+                        if dry_run {
+                            println!("Upgrading {}'s dependency on {} to `{}` (from `{}`)", pkg.name, pkg_meta.name, new_req, dep.req);
+                        } else {
+                            cargo::set_dependency_version(&pkg.manifest_path, &pkg_meta.name, &new_req)?;
+                        }
                     }
                 },
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
             new_version_string
         ));
         if !dry_run {
-            cargo::set_manifest_version(&manifest_path, &new_version_string)?;
+            cargo::set_package_version(&manifest_path, &new_version_string)?;
             cargo::update_lock(&manifest_path)?;
         }
         for (pkg, dep) in find_dependents(&ws_meta, &pkg_meta) {
@@ -302,7 +302,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         let updated_version_string = version.to_string();
         replacements.insert("{{next_version}}", updated_version_string.clone());
         if !dry_run {
-            cargo::set_manifest_version(&manifest_path, &updated_version_string)?;
+            cargo::set_package_version(&manifest_path, &updated_version_string)?;
             cargo::update_lock(&manifest_path)?;
         }
         let commit_msg = replace_in(&pro_release_commit_msg, &replacements);

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,7 +418,7 @@ struct ReleaseOpt {
     /// Do not create git tag
     skip_tag: bool,
 
-    #[structopt(long = "dependent-version")]
+    #[structopt(long = "dependent-version", raw(possible_values = "&config::DependentVersion::variants()", case_insensitive = "true"))]
     /// Specify how workspace dependencies on this crate should be handed.
     dependent_version: Option<config::DependentVersion>,
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -176,70 +176,75 @@ impl VersionExt for Version {
     }
 }
 
-#[test]
-fn test_increment_alpha() {
-    let mut v = Version::parse("1.0.0").unwrap();
-    let _ = v.increment_alpha();
-    assert_eq!(v, Version::parse("1.0.1-alpha.1").unwrap());
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    let mut v2 = Version::parse("1.0.1-dev").unwrap();
-    let _ = v2.increment_alpha();
-    assert_eq!(v2, Version::parse("1.0.1-alpha.1").unwrap());
+    #[test]
+    fn test_increment_alpha() {
+        let mut v = Version::parse("1.0.0").unwrap();
+        let _ = v.increment_alpha();
+        assert_eq!(v, Version::parse("1.0.1-alpha.1").unwrap());
 
-    let mut v3 = Version::parse("1.0.1-alpha.1").unwrap();
-    let _ = v3.increment_alpha();
-    assert_eq!(v3, Version::parse("1.0.1-alpha.2").unwrap());
+        let mut v2 = Version::parse("1.0.1-dev").unwrap();
+        let _ = v2.increment_alpha();
+        assert_eq!(v2, Version::parse("1.0.1-alpha.1").unwrap());
 
-    let mut v4 = Version::parse("1.0.1-beta.1").unwrap();
-    assert!(v4.increment_alpha().is_err());
+        let mut v3 = Version::parse("1.0.1-alpha.1").unwrap();
+        let _ = v3.increment_alpha();
+        assert_eq!(v3, Version::parse("1.0.1-alpha.2").unwrap());
 
-    let mut v5 = Version::parse("1.0.1-1").unwrap();
-    assert!(v5.increment_alpha().is_err());
-}
+        let mut v4 = Version::parse("1.0.1-beta.1").unwrap();
+        assert!(v4.increment_alpha().is_err());
 
-#[test]
-fn test_increment_beta() {
-    let mut v = Version::parse("1.0.0").unwrap();
-    let _ = v.increment_beta();
-    assert_eq!(v, Version::parse("1.0.1-beta.1").unwrap());
+        let mut v5 = Version::parse("1.0.1-1").unwrap();
+        assert!(v5.increment_alpha().is_err());
+    }
 
-    let mut v2 = Version::parse("1.0.1-dev").unwrap();
-    let _ = v2.increment_beta();
-    assert_eq!(v2, Version::parse("1.0.1-beta.1").unwrap());
+    #[test]
+    fn test_increment_beta() {
+        let mut v = Version::parse("1.0.0").unwrap();
+        let _ = v.increment_beta();
+        assert_eq!(v, Version::parse("1.0.1-beta.1").unwrap());
 
-    let mut v2 = Version::parse("1.0.1-alpha.1").unwrap();
-    let _ = v2.increment_beta();
-    assert_eq!(v2, Version::parse("1.0.1-beta.1").unwrap());
+        let mut v2 = Version::parse("1.0.1-dev").unwrap();
+        let _ = v2.increment_beta();
+        assert_eq!(v2, Version::parse("1.0.1-beta.1").unwrap());
 
-    let mut v3 = Version::parse("1.0.1-beta.1").unwrap();
-    let _ = v3.increment_beta();
-    assert_eq!(v3, Version::parse("1.0.1-beta.2").unwrap());
+        let mut v2 = Version::parse("1.0.1-alpha.1").unwrap();
+        let _ = v2.increment_beta();
+        assert_eq!(v2, Version::parse("1.0.1-beta.1").unwrap());
 
-    let mut v4 = Version::parse("1.0.1-rc.1").unwrap();
-    assert!(v4.increment_beta().is_err());
+        let mut v3 = Version::parse("1.0.1-beta.1").unwrap();
+        let _ = v3.increment_beta();
+        assert_eq!(v3, Version::parse("1.0.1-beta.2").unwrap());
 
-    let mut v5 = Version::parse("1.0.1-1").unwrap();
-    assert!(v5.increment_beta().is_err());
-}
+        let mut v4 = Version::parse("1.0.1-rc.1").unwrap();
+        assert!(v4.increment_beta().is_err());
 
-#[test]
-fn test_increment_rc() {
-    let mut v = Version::parse("1.0.0").unwrap();
-    let _ = v.increment_rc();
-    assert_eq!(v, Version::parse("1.0.1-rc.1").unwrap());
+        let mut v5 = Version::parse("1.0.1-1").unwrap();
+        assert!(v5.increment_beta().is_err());
+    }
 
-    let mut v2 = Version::parse("1.0.1-dev").unwrap();
-    let _ = v2.increment_rc();
-    assert_eq!(v2, Version::parse("1.0.1-rc.1").unwrap());
+    #[test]
+    fn test_increment_rc() {
+        let mut v = Version::parse("1.0.0").unwrap();
+        let _ = v.increment_rc();
+        assert_eq!(v, Version::parse("1.0.1-rc.1").unwrap());
 
-    let mut v3 = Version::parse("1.0.1-rc.1").unwrap();
-    let _ = v3.increment_rc();
-    assert_eq!(v3, Version::parse("1.0.1-rc.2").unwrap());
-}
+        let mut v2 = Version::parse("1.0.1-dev").unwrap();
+        let _ = v2.increment_rc();
+        assert_eq!(v2, Version::parse("1.0.1-rc.1").unwrap());
 
-#[test]
-fn test_build() {
-    let mut v = Version::parse("1.0.0").unwrap();
-    let _ = v.metadata("git.123456");
-    assert_eq!(v, Version::parse("1.0.0+git.123456").unwrap());
+        let mut v3 = Version::parse("1.0.1-rc.1").unwrap();
+        let _ = v3.increment_rc();
+        assert_eq!(v3, Version::parse("1.0.1-rc.2").unwrap());
+    }
+
+    #[test]
+    fn test_assign_build() {
+        let mut v = Version::parse("1.0.0").unwrap();
+        let _ = v.metadata("git.123456");
+        assert_eq!(v, Version::parse("1.0.0+git.123456").unwrap());
+    }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -180,71 +180,75 @@ impl VersionExt for Version {
 mod test {
     use super::*;
 
-    #[test]
-    fn test_increment_alpha() {
-        let mut v = Version::parse("1.0.0").unwrap();
-        let _ = v.increment_alpha();
-        assert_eq!(v, Version::parse("1.0.1-alpha.1").unwrap());
+    mod increment {
+        use super::*;
 
-        let mut v2 = Version::parse("1.0.1-dev").unwrap();
-        let _ = v2.increment_alpha();
-        assert_eq!(v2, Version::parse("1.0.1-alpha.1").unwrap());
+        #[test]
+        fn alpha() {
+            let mut v = Version::parse("1.0.0").unwrap();
+            let _ = v.increment_alpha();
+            assert_eq!(v, Version::parse("1.0.1-alpha.1").unwrap());
 
-        let mut v3 = Version::parse("1.0.1-alpha.1").unwrap();
-        let _ = v3.increment_alpha();
-        assert_eq!(v3, Version::parse("1.0.1-alpha.2").unwrap());
+            let mut v2 = Version::parse("1.0.1-dev").unwrap();
+            let _ = v2.increment_alpha();
+            assert_eq!(v2, Version::parse("1.0.1-alpha.1").unwrap());
 
-        let mut v4 = Version::parse("1.0.1-beta.1").unwrap();
-        assert!(v4.increment_alpha().is_err());
+            let mut v3 = Version::parse("1.0.1-alpha.1").unwrap();
+            let _ = v3.increment_alpha();
+            assert_eq!(v3, Version::parse("1.0.1-alpha.2").unwrap());
 
-        let mut v5 = Version::parse("1.0.1-1").unwrap();
-        assert!(v5.increment_alpha().is_err());
-    }
+            let mut v4 = Version::parse("1.0.1-beta.1").unwrap();
+            assert!(v4.increment_alpha().is_err());
 
-    #[test]
-    fn test_increment_beta() {
-        let mut v = Version::parse("1.0.0").unwrap();
-        let _ = v.increment_beta();
-        assert_eq!(v, Version::parse("1.0.1-beta.1").unwrap());
+            let mut v5 = Version::parse("1.0.1-1").unwrap();
+            assert!(v5.increment_alpha().is_err());
+        }
 
-        let mut v2 = Version::parse("1.0.1-dev").unwrap();
-        let _ = v2.increment_beta();
-        assert_eq!(v2, Version::parse("1.0.1-beta.1").unwrap());
+        #[test]
+        fn beta() {
+            let mut v = Version::parse("1.0.0").unwrap();
+            let _ = v.increment_beta();
+            assert_eq!(v, Version::parse("1.0.1-beta.1").unwrap());
 
-        let mut v2 = Version::parse("1.0.1-alpha.1").unwrap();
-        let _ = v2.increment_beta();
-        assert_eq!(v2, Version::parse("1.0.1-beta.1").unwrap());
+            let mut v2 = Version::parse("1.0.1-dev").unwrap();
+            let _ = v2.increment_beta();
+            assert_eq!(v2, Version::parse("1.0.1-beta.1").unwrap());
 
-        let mut v3 = Version::parse("1.0.1-beta.1").unwrap();
-        let _ = v3.increment_beta();
-        assert_eq!(v3, Version::parse("1.0.1-beta.2").unwrap());
+            let mut v2 = Version::parse("1.0.1-alpha.1").unwrap();
+            let _ = v2.increment_beta();
+            assert_eq!(v2, Version::parse("1.0.1-beta.1").unwrap());
 
-        let mut v4 = Version::parse("1.0.1-rc.1").unwrap();
-        assert!(v4.increment_beta().is_err());
+            let mut v3 = Version::parse("1.0.1-beta.1").unwrap();
+            let _ = v3.increment_beta();
+            assert_eq!(v3, Version::parse("1.0.1-beta.2").unwrap());
 
-        let mut v5 = Version::parse("1.0.1-1").unwrap();
-        assert!(v5.increment_beta().is_err());
-    }
+            let mut v4 = Version::parse("1.0.1-rc.1").unwrap();
+            assert!(v4.increment_beta().is_err());
 
-    #[test]
-    fn test_increment_rc() {
-        let mut v = Version::parse("1.0.0").unwrap();
-        let _ = v.increment_rc();
-        assert_eq!(v, Version::parse("1.0.1-rc.1").unwrap());
+            let mut v5 = Version::parse("1.0.1-1").unwrap();
+            assert!(v5.increment_beta().is_err());
+        }
 
-        let mut v2 = Version::parse("1.0.1-dev").unwrap();
-        let _ = v2.increment_rc();
-        assert_eq!(v2, Version::parse("1.0.1-rc.1").unwrap());
+        #[test]
+        fn rc() {
+            let mut v = Version::parse("1.0.0").unwrap();
+            let _ = v.increment_rc();
+            assert_eq!(v, Version::parse("1.0.1-rc.1").unwrap());
 
-        let mut v3 = Version::parse("1.0.1-rc.1").unwrap();
-        let _ = v3.increment_rc();
-        assert_eq!(v3, Version::parse("1.0.1-rc.2").unwrap());
-    }
+            let mut v2 = Version::parse("1.0.1-dev").unwrap();
+            let _ = v2.increment_rc();
+            assert_eq!(v2, Version::parse("1.0.1-rc.1").unwrap());
 
-    #[test]
-    fn test_assign_build() {
-        let mut v = Version::parse("1.0.0").unwrap();
-        let _ = v.metadata("git.123456");
-        assert_eq!(v, Version::parse("1.0.0+git.123456").unwrap());
+            let mut v3 = Version::parse("1.0.1-rc.1").unwrap();
+            let _ = v3.increment_rc();
+            assert_eq!(v3, Version::parse("1.0.1-rc.2").unwrap());
+        }
+
+        #[test]
+        fn metadata() {
+            let mut v = Version::parse("1.0.0").unwrap();
+            let _ = v.metadata("git.123456");
+            assert_eq!(v, Version::parse("1.0.0+git.123456").unwrap());
+        }
     }
 }


### PR DESCRIPTION
Fixes #77 

This includes switching to CLI arguments using `enum` where possible.  The downside to `arg_enum!` is that `--help` will show the names in uppercase and accepts them case insensitively which is uncommon in CLIs.   We probably want to eventually roll our own set of `impl`s rather than relying on `arg_enum!`