### PR TITLE
Layered config support

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::ffi::OsStr;
 use std::path::Path;
 use std::process::Command;
 
@@ -7,7 +8,7 @@ use crate::error::FatalError;
 fn do_call(
     command: Vec<&str>,
     path: Option<&Path>,
-    envs: Option<BTreeMap<&str, &str>>,
+    envs: Option<BTreeMap<&OsStr, &OsStr>>,
     dry_run: bool,
 ) -> Result<bool, FatalError> {
     if dry_run {
@@ -30,9 +31,7 @@ fn do_call(
     }
 
     if let Some(e) = envs {
-        for (key, val) in e.iter() {
-            cmd.env(key, val);
-        }
+        cmd.envs(e.iter());
     }
 
     for arg in iter {
@@ -57,7 +56,7 @@ pub fn call_on_path(command: Vec<&str>, path: &Path, dry_run: bool) -> Result<bo
 
 pub fn call_with_env(
     command: Vec<&str>,
-    envs: BTreeMap<&str, &str>,
+    envs: BTreeMap<&OsStr, &OsStr>,
     path: &Path,
     dry_run: bool,
 ) -> Result<bool, FatalError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use structopt;
 #[cfg(test)]
 extern crate assert_fs;
 
+use std::ffi::OsStr;
 use std::path::Path;
 use std::process::exit;
 
@@ -269,9 +270,9 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
         if let Some(pre_rel_hook) = pre_release_hook {
             shell::log_info(&format!("Calling pre-release hook: {:?}", pre_rel_hook));
             let envs = btreemap! {
-                "PREV_VERSION" => prev_version_string.as_ref(),
-                "NEW_VERSION" => new_version_string.as_ref(),
-                "DRY_RUN" => if dry_run { "true" } else { "false" }
+                OsStr::new("PREV_VERSION") => prev_version_string.as_ref(),
+                OsStr::new("NEW_VERSION") => new_version_string.as_ref(),
+                OsStr::new("DRY_RUN") => OsStr::new(if dry_run { "true" } else { "false" }),
             };
             // we use dry_run environmental variable to run the script
             // so here we set dry_run=false and always execute the command.

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,11 +81,10 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
     let release_config = {
         let mut release_config = if let Some(custom_config_path) = custom_config_path_option {
             // when calling with -c option
-            config::resolve_custom_config(Path::new(custom_config_path))?
+            config::resolve_custom_config(Path::new(custom_config_path))?.unwrap_or_default()
         } else {
             config::resolve_config(&manifest_path)?
-        }
-        .unwrap_or_default();
+        };
         release_config.update(args);
         release_config
     };
@@ -407,7 +406,7 @@ struct ReleaseOpt {
     level: version::BumpLevel,
 
     #[structopt(short = "c", long = "config")]
-    /// Custom config file
+    /// Custom config file (isolated)
     config: Option<String>,
 
     #[structopt(short = "m")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,6 +273,8 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
                 OsStr::new("PREV_VERSION") => prev_version_string.as_ref(),
                 OsStr::new("NEW_VERSION") => new_version_string.as_ref(),
                 OsStr::new("DRY_RUN") => OsStr::new(if dry_run { "true" } else { "false" }),
+                OsStr::new("WORKSPACE_ROOT") => ws_meta.workspace_root.as_os_str(),
+                OsStr::new("CRATE_ROOT") => manifest_path.parent().unwrap_or_else(|| Path::new(".")).as_os_str(),
             };
             // we use dry_run environmental variable to run the script
             // so here we set dry_run=false and always execute the command.

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ fn execute(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
             // when calling with -c option
             config::resolve_custom_config(Path::new(custom_config_path))?.unwrap_or_default()
         } else {
-            config::resolve_config(&manifest_path)?
+            config::resolve_config(&ws_meta.workspace_root, &manifest_path)?
         };
         release_config.update(args);
         release_config


### PR DESCRIPTION
Includes loading a workspace-wide config.  To make hooks still work, this also adds environment variables to access the workspace and crate paths.

Fixes #93 
