### PR TITLE
Use {{next_version}} in default for pro_release_commit_message

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -231,7 +231,7 @@ impl Config {
         self.pro_release_commit_message
             .as_ref()
             .map(|s| s.as_str())
-            .unwrap_or("(cargo-release) start next development iteration {{version}}")
+            .unwrap_or("(cargo-release) start next development iteration {{next_version}}")
     }
 
     pub fn pre_release_replacements(&self) -> &[Replace] {


### PR DESCRIPTION
The default value for `pro_release_commit_message` was using `{{version}}` instead of `{{next_version}}`.