### PR TITLE
Support git tag "--edit" option

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -51,6 +51,7 @@ Configuration is read from the following (in precedence order)
 | `tag-message`  | \-              | string | A message template for tag. The placeholder `{{tag_name}}` and ``{{prefix}}` (the tag prefix) is supported in addition to the global placeholders mentioned below. |
 | `tag-prefix`   | `--tag-prefix`  | string | Prefix of git tag, note that this will override default prefix based on crate name. |
 | `tag-name`     | `--tag-name`    | string | The name of the git tag.  The placeholder `{{prefix}}` (the tag prefix) is supported in addition to the global placeholders mentioned below. |
+| `tag-edit`     | `--tag-edit`    | bool | Edit git tag message interactively, see git tag [--edit](https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---edit) option. |
 | `doc-commit-message` | \-        | string | A commit message template for doc import. |
 | `no-dev-version` | `--no-dev-version` |  bool | Disable version bump after release. |
 | `pre-release-replacements` | \-   | array of tables (see below) | Specify files that cargo-release will search and replace with new version |

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,8 @@ pub trait ConfigSource {
         None
     }
 
+    fn tag_edit(&self) -> Option<bool> { None }
+
     fn tag_prefix(&self) -> Option<&str> {
         None
     }
@@ -106,6 +108,7 @@ pub struct Config {
     pub pre_release_replacements: Option<Vec<Replace>>,
     pub pre_release_hook: Option<Command>,
     pub tag_message: Option<String>,
+    pub tag_edit: Option<bool>,
     pub tag_prefix: Option<String>,
     pub tag_name: Option<String>,
     pub doc_commit_message: Option<String>,
@@ -161,6 +164,9 @@ impl Config {
         }
         if let Some(tag_name) = source.tag_name() {
             self.tag_name = Some(tag_name.to_owned());
+        }
+        if let Some(tag_edit) = source.tag_edit() {
+            self.tag_edit = Some(tag_edit);
         }
         if let Some(doc_commit_message) = source.doc_commit_message() {
             self.doc_commit_message = Some(doc_commit_message.to_owned());
@@ -252,6 +258,10 @@ impl Config {
             .unwrap_or("(cargo-release) {{crate_name}} version {{version}}")
     }
 
+    pub fn tag_edit(&self) -> bool {
+        self.tag_edit.unwrap_or(false)
+    }
+
     pub fn tag_prefix(&self) -> Option<&str> {
         self.tag_prefix.as_ref().map(|s| s.as_str())
     }
@@ -341,6 +351,10 @@ impl ConfigSource for Config {
 
     fn tag_message(&self) -> Option<&str> {
         self.tag_message.as_ref().map(|s| s.as_str())
+    }
+
+    fn tag_edit(&self) -> Option<bool> {
+        self.tag_edit
     }
 
     fn tag_prefix(&self) -> Option<&str> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -29,6 +29,7 @@ pub fn tag(
     name: &str,
     msg: &str,
     sign: bool,
+    edit: bool,
     dry_run: bool,
 ) -> Result<bool, FatalError> {
     call_on_path(
@@ -40,6 +41,7 @@ pub fn tag(
             "-m",
             msg,
             if sign { "-s" } else { "" },
+            if edit { "-e" } else { "" },
         ],
         dir,
         dry_run,

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,9 +406,9 @@ fn release_package(
 
     if !pkg.config.disable_tag() {
         let tag_message = replace_in(pkg.config.tag_message(), &replacements);
-
+        let edit = pkg.config.tag_edit();
         shell::log_info(&format!("Creating git tag {}", tag_name));
-        if !git::tag(cwd, &tag_name, &tag_message, sign, dry_run)? {
+        if !git::tag(cwd, &tag_name, &tag_message, sign, edit, dry_run)? {
             // tag failed, abort release
             return Ok(104);
         }
@@ -552,6 +552,10 @@ struct ConfigArgs {
     #[structopt(long = "tag-name")]
     /// The name of the git tag.
     tag_name: Option<String>,
+
+    #[structopt(long = "tag-edit")]
+    /// Edit git tag message
+    tag_edit: Option<bool>,
 
     #[structopt(long = "dev-version-ext")]
     /// Pre-release identifier(s) to append to the next development version after release


### PR DESCRIPTION
In our use-case, we want to add the changelog manually as the tag message, we can easily do it by adding `git tag` [--edit](https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---edit) support.