### PR TITLE
fix(git): Error on untracked files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ fn release_workspace(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
 
     git::git_version()?;
 
-    if !git::status(&ws_meta.workspace_root)? {
+    if git::is_dirty(&ws_meta.workspace_root)? {
         shell::log_warn("Uncommitted changes detected, please commit before release.");
         if !args.dry_run {
             return Ok(101);


### PR DESCRIPTION
`git publish` will error on uncommitted changes and untracked files.  We
only had one of these checks, causing us to fail part way through the
release if there was a stale file aorund.

Fixes #145