### PR TITLE
 feat(git): Notify user on unchanged crates 

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -10,6 +10,7 @@ pub fn is_dirty(dir: &Path) -> Result<bool, FatalError> {
         .arg("diff")
         .arg("HEAD")
         .arg("--exit-code")
+        .arg("--name-only")
         .current_dir(dir)
         .output()
         .map_err(FatalError::from)?;


### PR DESCRIPTION
Ideally, we could give people the option to skip unchanged crates.
We're starting conservativly though in case there are changes that won't
always be detected this way (like updates to dependencies). The big
concern is making this smart enough that people stop thinking while
still being dumb enough that people should still think.

For now, this incorrectly identifies crates as unchanged during dry-run
if we'd update its dependencies as part of releasing a dependency that
lives in the workspace.

For now, this does not respect `package.exclude`, so changes may occur
that should not force the crate to be released.

Fixes #143

BREAKING CHANGE: `{{tag_prefix}}` is now calculated before `{{version}}`
is updated to the current version and should not be trusted.