### PR TITLE
 refactor: Pre-compute some information 

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -17,7 +17,7 @@ fn cargo() -> String {
 pub fn publish(
     dry_run: bool,
     manifest_path: &Path,
-    features: Features,
+    features: &Features,
 ) -> Result<bool, FatalError> {
     let cargo = cargo();
     match features {

--- a/src/config.rs
+++ b/src/config.rs
@@ -266,8 +266,12 @@ impl Config {
             .unwrap_or("(cargo-release) {{crate_name}} version {{version}}")
     }
 
-    pub fn tag_prefix(&self) -> Option<&str> {
-        self.tag_prefix.as_ref().map(|s| s.as_str())
+    pub fn tag_prefix(&self, is_root: bool) -> &str {
+        // crate_name as default tag prefix for multi-crate project
+        self.tag_prefix
+            .as_ref()
+            .map(|s| s.as_str())
+            .unwrap_or_else(|| if !is_root { "{{crate_name}}-" } else { "" })
     }
 
     pub fn tag_name(&self) -> &str {

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,14 +212,7 @@ fn release_package(
 
     let root = git::top_level(cwd)?;
     let is_root = root == cwd;
-    let tag_prefix = pkg.config.tag_prefix().unwrap_or_else(|| {
-        // crate_name as default tag prefix for multi-crate project
-        if !is_root {
-            "{{crate_name}}-"
-        } else {
-            ""
-        }
-    });
+    let tag_prefix = pkg.config.tag_prefix(is_root);
     let tag_prefix = replace_in(&tag_prefix, &replacements);
     replacements.insert("{{prefix}}", tag_prefix.clone());
 


### PR DESCRIPTION
My goal is to reduce the release logic to eventually allow
- Doing "anything unchanged" checks before the confirmation prompt
- Include dependency updates  in "anything unchanged" when running in
  dry-run mode
- A single confirmation prompt
- Potentially consolidate commits
- Consolidate pushes

This stopped short of the refactorings needed to unlock these changes
because it was getting to big.