### PR TITLE
Batch process each step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,6 +469,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ppv-lite86"
@@ -1006,6 +1012,7 @@ dependencies = [
 "checksum normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2e0a1a39eab95caf4f5556da9289b9e68f0aafac901b2ce80daaf020d3b733a8"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+"checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ chrono = "0.4"
 dirs = "2.0"
 boolinator = "2.4"
 difference = "2.0"
+once_cell = "1.2.0"
 structopt = {version = "0.3.0", default-features = false}
 clap = { version = "2", default-features = false }
 clap-cargo = { version = "0.2", features = ["cargo_metadata"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,9 @@ mod replace;
 mod shell;
 mod version;
 
+static NOW: once_cell::sync::Lazy<String> =
+    once_cell::sync::Lazy::new(|| Local::now().format("%Y-%m-%d").to_string());
+
 fn find_dependents<'w>(
     ws_meta: &'w cargo_metadata::Metadata,
     pkg_meta: &'w cargo_metadata::Package,
@@ -339,7 +342,6 @@ fn release_package(
     let sign = pkg.config.sign_commit();
     let cwd = pkg.package_path;
     let crate_name = pkg.meta.name.as_str();
-    let now = Local::now().format("%Y-%m-%d").to_string();
 
     // STEP 2: update current version, save and commit
     if let Some(version) = pkg.version.as_ref() {
@@ -462,7 +464,7 @@ fn release_package(
                 prev_version: Some(&pkg.prev_version.version_string),
                 version: Some(&new_version_string),
                 crate_name: Some(crate_name),
-                date: Some(now.as_str()),
+                date: Some(NOW.as_str()),
                 tag_name: pkg.tag.as_ref().map(|s| s.as_str()),
                 ..Default::default()
             };
@@ -501,7 +503,7 @@ fn release_package(
             prev_version: Some(&pkg.prev_version.version_string),
             version: Some(&new_version_string),
             crate_name: Some(crate_name),
-            date: Some(now.as_str()),
+            date: Some(NOW.as_str()),
             ..Default::default()
         };
         let commit_msg = template.render(pkg.config.pre_release_commit_message());
@@ -547,7 +549,7 @@ fn release_package(
             version: Some(&base.version_string),
             crate_name: Some(crate_name),
             tag_name: Some(&tag_name),
-            date: Some(now.as_str()),
+            date: Some(NOW.as_str()),
             ..Default::default()
         };
         let tag_message = template.render(pkg.config.tag_message());
@@ -576,7 +578,7 @@ fn release_package(
             prev_version: Some(&pkg.prev_version.version_string),
             version: Some(&base.version_string),
             crate_name: Some(crate_name),
-            date: Some(now.as_str()),
+            date: Some(NOW.as_str()),
             next_version: Some(updated_version_string),
             ..Default::default()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn find_dependents<'w>(
     })
 }
 
-struct Package<'m> {
+struct PackageRelease<'m> {
     meta: &'m cargo_metadata::Package,
     manifest_path: &'m Path,
     package_path: &'m Path,
@@ -71,7 +71,7 @@ struct Version {
     version_string: String,
 }
 
-impl<'m> Package<'m> {
+impl<'m> PackageRelease<'m> {
     fn load(
         args: &ReleaseOpt,
         git_root: &Path,
@@ -196,7 +196,7 @@ impl<'m> Package<'m> {
             }
         };
 
-        let pkg = Package {
+        let pkg = PackageRelease {
             meta: pkg_meta,
             manifest_path,
             package_path: cwd,
@@ -234,7 +234,7 @@ fn release_workspace(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
     let root = git::top_level(&ws_meta.workspace_root)?;
     let pkgs: Result<HashMap<_, _>, _> = selected_pkgs
         .iter()
-        .map(|p| Package::load(args, &root, &ws_meta, p).map(|p| (&p.meta.id, p)))
+        .map(|p| PackageRelease::load(args, &root, &ws_meta, p).map(|p| (&p.meta.id, p)))
         .collect();
     let pkgs = pkgs?;
 
@@ -304,7 +304,7 @@ fn sort_workspace_inner<'m>(
 fn release_package(
     args: &ReleaseOpt,
     ws_meta: &cargo_metadata::Metadata,
-    pkg: &Package<'_>,
+    pkg: &PackageRelease<'_>,
 ) -> Result<i32, error::FatalError> {
     // STEP 1: Query a bunch of information for later use.
     let dry_run = args.dry_run;

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,17 +357,6 @@ fn release_packages<'m>(
             }
 
             let new_version_string = version.version_string.as_str();
-            // Release Confirmation
-            if !dry_run && !args.no_confirm {
-                let confirmed = shell::confirm(&format!(
-                    "Release version {} {}?",
-                    crate_name, new_version_string
-                ));
-                if !confirmed {
-                    return Ok(0);
-                }
-            }
-
             log::info!("Update {} to version {}", crate_name, new_version_string);
             if !dry_run {
                 cargo::set_package_version(&pkg.manifest_path, &new_version_string)?;


### PR DESCRIPTION
Instead of processing one crate at a time across all steps, we're going to process one step at a time across all crates.   I have no idea if, in the end, this will make it easier or harder to recover.  The main goal is to work towards:
- Doing "anything unchanged" checks before the confirmation prompt
- Include dependency updates  in "anything unchanged" when running in
  dry-run mode, https://github.com/sunng87/cargo-release/issues/150
- A single confirmation prompt, https://github.com/sunng87/cargo-release/issues/138
- Potentially consolidate commits, https://github.com/sunng87/cargo-release/issues/138
- Consolidate pushes, https://github.com/sunng87/cargo-release/issues/138

Besides how things are processed, this does change
- A single push of HEAD is done rather than once per crate (we still push once per tag)
- We confirm once
- We confirm regardless of version change happening.