### PR TITLE
Add allow-dirty flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Performs release best-practices, including:
 
-* Ensure the git working directory is clean.
+* Ensure the git working directory is clean (except if the `--allow-dirty` flag is set).
 * Bump the version in Cargo.toml
 * Run `cargo publish` ([if not disabled](https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish--field-optional))
 * Create a git tag for this version

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -5,11 +5,12 @@
 | Argument        | Format | Description |
 |-----------------|--------|-------------|
 | `--dry-run`     | bool   | Do nothing; report what would happen |
-| `--no-confirm`  | bool   | Release the crate without the user verifying what will happen. |
+| `--no-confirm`  | bool   | Release the crate without the user verifying what will happen |
 | `--isolated`    | bool   | Do not search for config files |
+| `--allow-dirty` | bool   | Allow dirty working directories to be published |
 | `--config`      | string | Load a config file from disk |
-| `<LEVEL>`       | string | Bump specified version field. |
-| `--metadata`    | string | Populate the metadata field in the version. |
+| `<LEVEL>`       | string | Bump specified version field |
+| `--metadata`    | string | Populate the metadata field in the version |
 
 ### Bump level
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -16,42 +16,30 @@ fn cargo() -> String {
 
 pub fn publish(
     dry_run: bool,
+    allow_dirty: bool,
     manifest_path: &Path,
     features: &Features,
 ) -> Result<bool, FatalError> {
     let cargo = cargo();
-    match features {
-        Features::None => call(
-            vec![
-                &cargo,
-                "publish",
-                "--manifest-path",
-                manifest_path.to_str().unwrap(),
-            ],
-            dry_run,
-        ),
-        Features::Selective(vec) => call(
-            vec![
-                &cargo,
-                "publish",
-                "--features",
-                &vec.join(" "),
-                "--manifest-path",
-                manifest_path.to_str().unwrap(),
-            ],
-            dry_run,
-        ),
-        Features::All => call(
-            vec![
-                &cargo,
-                "publish",
-                "--all-features",
-                "--manifest-path",
-                manifest_path.to_str().unwrap(),
-            ],
-            dry_run,
-        ),
+    let mut publish_call: Vec<&str> = vec![&cargo, "publish"];
+    if allow_dirty {
+        publish_call.push("--allow-dirty")
     }
+    let feature_vec;
+    match features {
+        Features::None => {}
+        Features::Selective(vec) => {
+            publish_call.push("--features");
+            feature_vec = vec.join(" ");
+            publish_call.push(&feature_vec);
+        }
+        Features::All => {
+            publish_call.push("--all-features");
+        }
+    }
+    publish_call.push("--manifest-path");
+    publish_call.push(manifest_path.to_str().unwrap());
+    call(publish_call, dry_run)
 }
 
 pub fn set_package_version(manifest_path: &Path, version: &str) -> Result<(), FatalError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,7 +242,7 @@ fn release_workspace(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
     let ws_meta = args.manifest.metadata().exec().map_err(FatalError::from)?;
 
     git::git_version()?;
-    if git::is_dirty(&ws_meta.workspace_root)? {
+    if !args.allow_dirty && git::is_dirty(&ws_meta.workspace_root)? {
         log::warn!("Uncommitted changes detected, please commit before release.");
         if !args.dry_run {
             return Ok(101);
@@ -548,7 +548,7 @@ fn release_packages<'m>(
             log::info!("Running cargo publish on {}", crate_name);
             // feature list to release
             let features = &pkg.features;
-            if !cargo::publish(dry_run, &pkg.manifest_path, features)? {
+            if !cargo::publish(dry_run, args.allow_dirty, &pkg.manifest_path, features)? {
                 return Ok(103);
             }
         }
@@ -673,7 +673,7 @@ struct ReleaseOpt {
     custom_config: Option<String>,
 
     #[structopt(long)]
-    /// Ignore implicit configuration files.
+    /// Ignore implicit configuration files
     isolated: bool,
 
     #[structopt(flatten)]
@@ -684,11 +684,16 @@ struct ReleaseOpt {
     dry_run: bool,
 
     #[structopt(long)]
+    /// Allow dirty working directories to be published
+    allow_dirty: bool,
+
+
+    #[structopt(long)]
     /// Skip release confirmation and version preview
     no_confirm: bool,
 
     #[structopt(long)]
-    /// The name of tag for the previous release.
+    /// The name of tag for the previous release
     prev_tag_name: Option<String>,
 
     #[structopt(flatten)]


### PR DESCRIPTION
Add flag to allow releases with a dirty repository. Analog to the other cargo calls such as `cargo publish`.   