### PR TITLE
Allow commits in a workspace to be consolidated.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -41,25 +41,3 @@ pre-release-replacements = [ {file="CHANGELOG.md", search="Unreleased", replace=
 current release version and date.
 
 You can find a real world example in a [handlebars-rust release commit](https://github.com/sunng87/handlebars-rust/commit/ca60fce3e1fce68f427d097d0706a7194600b982#diff-80398c5faae3c069e4e6aa2ed11b28c0)
-
-
-## How do I upload my rustdoc documentation?
-
-Most of the time, [docs.rs](https://docs.rs/about) service will be good enough
-for managing your documentation.  It will automatically generate and post your
-documentation when publishing your crate.
-
-However, if you wish to maintain your own copy (like for your unpublished
-`master`), you can use `--upload-doc` option, cargo-release will generate
-rustdoc during release process, and commit the doc directory to `gh-pages`
-branch. So you can access your rust doc at
-https://YOUR-GITHUB-USERNAME.github.io/YOUR-REPOSITORY-NAME/YOUR-CRATE-NAME
-
-If your hosting service uses different branch for pages, you can use
-`--doc-branch` to customize the branch we push docs to.
-
-#### WARNING
-
-This option will override your existed doc branch,
-use it at your own risk.
-

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -29,8 +29,8 @@ Configuration is read from the following (in precedence order)
 
 - Command line arguments
 - File specified via `--config PATH`
-- `$CRATE/release.toml`
 - `$CRATE/Cargo.toml` (`[package.metadata.release]` table)
+- `$CRATE/release.toml`
 - `$WORKSPACE/release.toml`
 - `$HOME/.release.toml`
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -44,6 +44,7 @@ Configuration is read from the following (in precedence order)
 | `disable-tag`  | `--skip-tag`    | bool   | Don't do git tag |
 | `disable-publish` | `--skip-publish` |  bool | Don't do cargo publish right now, see [manifest `publish` field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish--field-optional) to permanently disable publish. |
 | `dev-version-ext` | `--dev-version-ext` | string | Pre-release extension to use on the next development version. |
+| `consolidate-commits` | \- | bool | When releasing a workspace, use a single commit for the pre-release version bump and a single commit for the post-release version bump. |
 | `pre-release-commit-message` | \- | string | A commit message template for release. For example: `"release {{version}}"`, where `{{version}}` will be replaced by actual version. |
 | `post-release-commit-message` | \- | string | A commit message template for bumping version after release. For example: `Released {{version}}, starting {{next_version}}`. The placeholder `{{next_version}}` (the version in git after release) is supported in addition to the global placeholders mentioned below. |
 | `tag-message`  | \-              | string | A message template for tag. The placeholder `{{tag_name}}` and `{{prefix}}` (the tag prefix) is supported in addition to the global placeholders mentioned below. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -439,9 +439,11 @@ pub fn resolve_custom_config(file_path: &Path) -> Result<Option<Config>, FatalEr
 /// This tries the following sources in order, merging the results:
 /// 1. $HOME/.release.toml
 /// 2. $(workspace)/release.toml
-/// 3. $(crate)/Cargo.toml `package.metadata.release` (with deprecation warning)
 /// 4. $(crate)/release.toml
+/// 3. $(crate)/Cargo.toml `package.metadata.release`
 ///
+/// `$(crate)/Cargo.toml` is a way to differentiate configuration for the root crate and the
+/// workspace.
 pub fn resolve_config(workspace_root: &Path, manifest_path: &Path) -> Result<Config, FatalError> {
     let mut config = Config::default();
 
@@ -464,15 +466,15 @@ pub fn resolve_config(workspace_root: &Path, manifest_path: &Path) -> Result<Con
         };
     }
 
-    // Crate manifest.
-    let current_dir_config = get_config_from_manifest(manifest_path)?;
+    // Project release file.
+    let default_config = crate_root.join("release.toml");
+    let current_dir_config = get_config_from_file(&default_config)?;
     if let Some(cfg) = current_dir_config {
         config.update(&cfg);
     };
 
-    // Project release file.
-    let default_config = crate_root.join("release.toml");
-    let current_dir_config = get_config_from_file(&default_config)?;
+    // Crate manifest.
+    let current_dir_config = get_config_from_manifest(manifest_path)?;
     if let Some(cfg) = current_dir_config {
         config.update(&cfg);
     };


### PR DESCRIPTION
To support workspace-wide configuration, we had to make a small tweak to how the config layering works.  We already needed to do this to help people who want different defaults for their workspace and their root crate.  I thought it already behaved this way and was suggesting people take advantage of it to work around their problems.

I was lazy and also included a documentation update for a past change.