### PR TITLE
Give users better control over file-replacements

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,10 +64,10 @@ bumping version:
 ```toml
 pre-release-replacements = [
   {file="CHANGELOG.md", search="Unreleased", replace="{{version}}"},
-  {file="CHANGELOG.md", search="\\.\\.\\.HEAD", replace="...{{tag_name}}"},
+  {file="CHANGELOG.md", search="\\.\\.\\.HEAD", replace="...{{tag_name}}", exactly=1},
   {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}"},
-  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate"},
-  {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/assert-rs/predicates-rs/compare/{{tag_name}}...HEAD"},
+  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate", exactly=1},
+  {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/assert-rs/predicates-rs/compare/{{tag_name}}...HEAD", exactly=1},
 ]
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -66,6 +66,7 @@ This field is an array of tables with the following
 * `min` (default is `1`): Minimum occurrences of `search`.
 * `max` (optional): Maximum occurrences of `search`.
 * `exactly` (optional): Number of occurrences of `search`.
+* `prerelease` (default is `false`): Run the replacement when bumping to a pre-release level.
 
 See [release.toml](https://github.com/sunng87/cargo-release/blob/master/release.toml) for example.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -63,6 +63,9 @@ This field is an array of tables with the following
 * `file`: the file to search and replace
 * `search`: regex that matches string you want to replace
 * `replace`: the replacement string; you can use the any of the placeholders mentioned below.
+* `min` (default is `1`): Minimum occurrences of `search`.
+* `max` (optional): Maximum occurrences of `search`.
+* `exactly` (optional): Number of occurrences of `search`.
 
 See [release.toml](https://github.com/sunng87/cargo-release/blob/master/release.toml) for example.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -365,6 +365,9 @@ pub struct Replace {
     pub file: PathBuf,
     pub search: String,
     pub replace: String,
+    pub min: Option<usize>,
+    pub max: Option<usize>,
+    pub exactly: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -368,6 +368,8 @@ pub struct Replace {
     pub min: Option<usize>,
     pub max: Option<usize>,
     pub exactly: Option<usize>,
+    #[serde(default)]
+    pub prerelease: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,6 +84,14 @@ quick_error! {
             display("RegexError {}", err)
             description(err.description())
         }
+        ReplacerMinError(pattern: String, req: usize, actual: usize) {
+            display("For `{}`, at least {} replacements expected, found {}", pattern, req, actual)
+            description("Too few replacements")
+        }
+        ReplacerMaxError(pattern: String, req: usize, actual: usize) {
+            display("For `{}`, at most {} replacements expected, found {}", pattern, req, actual)
+            description("Too many replacements")
+        }
         VarError(err: VarError) {
             from()
             cause(err)

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,10 +553,12 @@ fn release_packages<'m>(
                     tag_name: pkg.tag.as_ref().map(|s| s.as_str()),
                     ..Default::default()
                 };
+                let prerelease = !version.version.pre.is_empty();
                 do_file_replacements(
                     pkg.config.pre_release_replacements(),
                     &template,
                     cwd,
+                    prerelease,
                     dry_run,
                 )?;
             }

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -50,18 +50,23 @@ pub fn do_file_replacements(
     replace_config: &[Replace],
     template: &Template<'_>,
     cwd: &Path,
+    prerelease: bool,
     dry_run: bool,
 ) -> Result<bool, FatalError> {
     for replace in replace_config {
-        let file = cwd.join(replace.file.as_path());
-        let pattern = replace.search.as_str();
-        let to_replace = replace.replace.as_str();
+        if replace.prerelease && prerelease {
+            log::debug!("Pre-release, not replacing {}", replace.search);
+            continue;
+        }
 
+        let to_replace = replace.replace.as_str();
         let replacer = template.render(to_replace);
 
+        let file = cwd.join(replace.file.as_path());
         log::debug!("Substituting values for {}", file.display());
         let data = std::fs::read_to_string(&file)?;
 
+        let pattern = replace.search.as_str();
         let r = Regex::new(pattern).map_err(FatalError::from)?;
         let min = replace.min.or(replace.exactly).unwrap_or(1);
         let max = replace.min.or(replace.exactly).unwrap_or(std::usize::MAX);

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -63,6 +63,23 @@ pub fn do_file_replacements(
         let data = std::fs::read_to_string(&file)?;
 
         let r = Regex::new(pattern).map_err(FatalError::from)?;
+        let min = replace.min.or(replace.exactly).unwrap_or(1);
+        let max = replace.min.or(replace.exactly).unwrap_or(std::usize::MAX);
+        let actual = r.find_iter(&data).count();
+        if actual < min {
+            return Err(FatalError::ReplacerMinError(
+                pattern.to_owned(),
+                min,
+                actual,
+            ))?;
+        } else if max < actual {
+            return Err(FatalError::ReplacerMaxError(
+                pattern.to_owned(),
+                min,
+                actual,
+            ))?;
+        }
+
         let result = r.replace_all(&data, replacer.as_str());
 
         if dry_run {


### PR DESCRIPTION
This has two breaking changes
- For each replacement, an error will occur if no matches for the pattern are found.  This can be reverted with `min = 0`
- Replacements will only happen on major/minor/patch releases. To have a replacement happen on a pre-release, set `prerelease = true`.

Fixes #185 
Fixes #113 