### PR TITLE
Feature/bump to specific version

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -19,7 +19,12 @@
   * Otherwise, bump the patch field (0.1.0 -> 0.1.1)
 * `minor`: Bump minor version (0.1.0-pre -> 0.2.0)
 * `major`: Bump major version (0.1.0-pre -> 1.0.0)
-* `alpha`, `beta`, and `rc`: Add/increment pre-release to your version (1.0.0 -> 1.0.1-rc.1, 1.0.1-dev -> 1.0.1-rc.1, 1.0.1-rc.1 -> 1.0.1-rc.2)
+* `alpha`, `beta`, and `rc`: Add/increment pre-release to your version
+  (1.0.0 -> 1.0.1-rc.1, 1.0.1-dev -> 1.0.1-rc.1, 1.0.1-rc.1 ->
+  1.0.1-rc.2)
+* *[version]*: bump version to given version. The version has to
+  be a valid semver string and greater than current version as in
+  semver spec.
 
 ## Configuration
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,18 +178,33 @@ impl<'m> PackageRelease<'m> {
 
         let version = {
             let mut potential_version = prev_version.version.clone();
-            if args
-                .level
-                .bump_version(&mut potential_version, args.metadata.as_ref())?
-            {
-                let version = potential_version;
-                let version_string = version.to_string();
-                Some(Version {
-                    version,
-                    version_string,
-                })
+            if let Ok(bump_level) = BumpLevel::from_str(&args.level) {
+                // bump level
+                if bump_level.bump_version(&mut potential_version, args.metadata.as_ref())? {
+                    let version = potential_version;
+                    let version_string = version.to_string();
+                    Some(Version {
+                        version,
+                        version_string,
+                    })
+                } else {
+                    None
+                }
             } else {
-                None
+                // given version
+                let new_version = semver::Version::from(&args.level);
+                if new_version > potential_version {
+                    Some(version {
+                        new_version,
+                        args.level.to_owned(),
+                    })
+                } else if new_version = potential_version {
+                    None
+                } else {
+                    return error::FatalError::UnsupportedVersionReq(
+                        "Cannot release version smaller than current one",
+                    );
+                }
             }
         };
         let dependents = if version.is_some() {
@@ -772,7 +787,7 @@ struct ReleaseOpt {
         case_insensitive(true),
         default_value = "release"
     )]
-    level: version::BumpLevel,
+    level: String,
 
     #[structopt(short = "m")]
     /// Semver metadata

--- a/src/main.rs
+++ b/src/main.rs
@@ -786,11 +786,7 @@ struct ReleaseOpt {
     workspace: clap_cargo::Workspace,
 
     /// Release level: bumping specified version field or remove prerelease extensions by default
-    #[structopt(
-        possible_values(&version::BumpLevel::variants()),
-        case_insensitive(true),
-        default_value = "release"
-    )]
+    #[structopt(case_insensitive(true), default_value = "release")]
     level: String,
 
     #[structopt(short = "m")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ impl<'m> PackageRelease<'m> {
         let mut is_pre_release = false;
         let version = {
             let mut potential_version = prev_version.version.clone();
-            if let Ok(bump_level) = version::BumpLevel::from_str(&args.level) {
+            if let Ok(bump_level) = version::BumpLevel::from_str(&args.level_or_version) {
                 // bump level
                 if bump_level.bump_version(&mut potential_version, args.metadata.as_ref())? {
                     let version = potential_version;
@@ -195,12 +195,13 @@ impl<'m> PackageRelease<'m> {
                 }
             } else {
                 // given version
-                let new_version = semver::Version::parse(&args.level).map_err(FatalError::from)?;
+                let new_version =
+                    semver::Version::parse(&args.level_or_version).map_err(FatalError::from)?;
                 if new_version > potential_version {
                     is_pre_release = new_version.is_prerelease();
                     Some(Version {
                         version: new_version,
-                        version_string: args.level.to_owned(),
+                        version_string: args.level_or_version.to_owned(),
                     })
                 } else if new_version == potential_version {
                     None
@@ -785,9 +786,9 @@ struct ReleaseOpt {
     #[structopt(flatten)]
     workspace: clap_cargo::Workspace,
 
-    /// Release level: bumping specified version field or remove prerelease extensions by default
+    /// Release level or version: bumping specified version field or remove prerelease extensions by default. Possible level value: major, minor, patch, release, rc, beta, alpha or any valid semver version that is greater than current version
     #[structopt(case_insensitive(true), default_value = "release")]
-    level: String,
+    level_or_version: String,
 
     #[structopt(short = "m")]
     /// Semver metadata


### PR DESCRIPTION
Fixes #188 

This patch added support for bumping version to a fixed one. And the given version has to be:

* A valid semver string
* A version that is greater than current one
