### PR TITLE
Add `--token` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 * Config: `exclude_paths` list of globs to get more accurate listing of files-changed [#149]
+* CLI: `--token` can be used to specify the token used by `cargo publish`
 
 ### Fixed
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -10,6 +10,7 @@
 | `--config`      | string | Load a config file from disk |
 | `<LEVEL>`       | string | Bump specified version field. |
 | `--metadata`    | string | Populate the metadata field in the version. |
+| `--token`       | string | Token to use when running `cargo publish` |
 
 ### Bump level
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -677,7 +677,12 @@ fn release_packages<'m>(
             log::info!("Running cargo publish on {}", crate_name);
             // feature list to release
             let features = &pkg.features;
-            if !cargo::publish(dry_run, &pkg.manifest_path, features)? {
+            if !cargo::publish(
+                dry_run,
+                &pkg.manifest_path,
+                features,
+                args.config.token.as_ref().map(AsRef::as_ref),
+            )? {
                 return Ok(103);
             }
             let timeout = std::time::Duration::from_secs(30);
@@ -927,6 +932,10 @@ struct ConfigArgs {
     #[structopt(long)]
     /// Enable all features via `all-features`. Overrides `features`
     all_features: bool,
+
+    #[structopt(long)]
+    /// Token to use when uploading
+    token: Option<String>,
 }
 
 impl config::ConfigSource for ConfigArgs {


### PR DESCRIPTION
Currently, the `cargo publish` step uses whichever token is in the users `~/.cargo/credentials`, or can be overriden by `CARGO_REGISTRY_TOKEN` (for crates.io), but it is sometimes convenient to specify the `--token` parameter for cargo publish, which this PR adds.