### PR TITLE
Increase timeout of wait_for_publish

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -687,7 +687,7 @@ fn release_packages<'m>(
             )? {
                 return Ok(103);
             }
-            let timeout = std::time::Duration::from_secs(30);
+            let timeout = std::time::Duration::from_secs(300);
 
             if pkg.config.registry().is_none() {
                 cargo::wait_for_publish(crate_name, &base.version_string, timeout, dry_run)?;


### PR DESCRIPTION
The timeout of `wait_for_publish` may be short because it requires disk access.
If the host is under heavy I/O load, `wait_for_publish` takes more than 30s.