### PR TITLE
Better error message when file to replace not found

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use std::env::VarError;
 use std::io::Error as IOError;
+use std::path::PathBuf;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 
@@ -16,6 +17,9 @@ quick_error! {
             from()
             cause(err)
             display("IO Error: {}", err)
+        }
+        FileNotFound(filename: PathBuf){
+            display("Unable to find file {} to perform replace", filename.display())
         }
         InvalidCargoFileFormat(err: TomlError) {
             display("Invalid TOML file format: {}", err)

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -64,6 +64,9 @@ pub fn do_file_replacements(
 
         let file = cwd.join(replace.file.as_path());
         log::debug!("Substituting values for {}", file.display());
+        if !file.exists() {
+            return Err(FatalError::FileNotFound(file));
+        }
         let data = std::fs::read_to_string(&file)?;
 
         let pattern = replace.search.as_str();


### PR DESCRIPTION
Previously the error message just said file not found as it was just `IOError`.
Added custom logic to check and show the filename in case a file needed for replace is not found.