### PR TITLE
Add config option: post-release-replacements

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -61,12 +61,13 @@ Configuration is read from the following (in precedence order)
 | `tag-name`     | `--tag-name`    | string | The name of the git tag.  The placeholder `{{prefix}}` (the tag prefix) is supported in addition to the global placeholders mentioned below. |
 | `dev-version-ext` | `--dev-version-ext` | string | Pre-release extension to use on the next development version. |
 | `no-dev-version` | `--no-dev-version` |  bool | Disable version bump after release. |
-| `pre-release-replacements` | \-   | array of tables (see below) | Specify files that cargo-release will search and replace with new version |
+| `pre-release-replacements` | \-   | array of tables (see below) | Specify files that cargo-release will search and replace with new version for the release commit |
+| `post-release-replacements` | \-   | array of tables (see below) | Specify files that cargo-release will search and replace with new version for the post-release commit (the one starting development) |
 | `pre-release-hook` | \-          | list of arguments | Provide a command to run before `cargo-release` commits version change. If the return code of hook command is greater than 0, the release process will be aborted. |
 | `enable-features` | `--features` | list of names | Provide a set of feature flags that should be passed to `cargo publish` (requires rust 1.33+) |
 | `all-features` | `--all-features` | bool  | Signal to `cargo publish`, that all features should be used (requires rust 1.33+) |
 
-### Pre-release Replacements
+### {Pre,Post}-release Replacements
 
 This field is an array of tables with the following
 
@@ -86,7 +87,7 @@ The following placeholders in configuration values will be be replaced with the 
 
 * `{{prev_version}}`: The version before `cargo-release` was executed (before any version bump).
 * `{{version}}`: The current (bumped) crate version.
-* `{{next_version}}` (only valid for `post-release-commit-message`): The crate version for starting development.
+* `{{next_version}}` (only valid for `post-release-{commit-message,replacements}`): The crate version for starting development.
 * `{{crate_name}}`: The name of the current crate in `Cargo.toml`.
 * `{{date}}`: The current date in `%Y-%m-%d` format.
 * `{{prefix}}` (only valid for `tag-name` / `tag-message`): The value prepended to the tag name.

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,10 @@ pub trait ConfigSource {
         None
     }
 
+    fn post_release_replacements(&self) -> Option<&[Replace]> {
+        None
+    }
+
     fn pre_release_hook(&self) -> Option<&Command> {
         None
     }
@@ -117,6 +121,7 @@ pub struct Config {
     pub pro_release_commit_message: Option<String>,
     pub post_release_commit_message: Option<String>,
     pub pre_release_replacements: Option<Vec<Replace>>,
+    pub post_release_replacements: Option<Vec<Replace>>,
     pub pre_release_hook: Option<Command>,
     pub tag_message: Option<String>,
     pub tag_prefix: Option<String>,
@@ -174,6 +179,9 @@ impl Config {
         }
         if let Some(pre_release_replacements) = source.pre_release_replacements() {
             self.pre_release_replacements = Some(pre_release_replacements.to_owned());
+        }
+        if let Some(post_release_replacements) = source.post_release_replacements() {
+            self.post_release_replacements = Some(post_release_replacements.to_owned());
         }
         if let Some(pre_release_hook) = source.pre_release_hook() {
             self.pre_release_hook = Some(pre_release_hook.to_owned());
@@ -263,6 +271,13 @@ impl Config {
 
     pub fn pre_release_replacements(&self) -> &[Replace] {
         self.pre_release_replacements
+            .as_ref()
+            .map(|v| v.as_ref())
+            .unwrap_or(&[])
+    }
+
+    pub fn post_release_replacements(&self) -> &[Replace] {
+        self.post_release_replacements
             .as_ref()
             .map(|v| v.as_ref())
             .unwrap_or(&[])
@@ -372,6 +387,10 @@ impl ConfigSource for Config {
 
     fn pre_release_replacements(&self) -> Option<&[Replace]> {
         self.pre_release_replacements.as_ref().map(|v| v.as_ref())
+    }
+
+    fn post_release_replacements(&self) -> Option<&[Replace]> {
+        self.post_release_replacements.as_ref().map(|v| v.as_ref())
     }
 
     fn pre_release_hook(&self) -> Option<&Command> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -764,9 +764,20 @@ fn release_packages<'m>(
                 version: Some(&base.version_string),
                 crate_name: Some(crate_name),
                 date: Some(NOW.as_str()),
+                tag_name: pkg.tag.as_ref().map(|s| s.as_str()),
                 next_version: Some(updated_version_string),
                 ..Default::default()
             };
+            if !pkg.config.post_release_replacements().is_empty() {
+                // try replacing text in configured files
+                do_file_replacements(
+                    pkg.config.post_release_replacements(),
+                    &template,
+                    cwd,
+                    false, // post-release replacements should always be applied
+                    dry_run,
+                )?;
+            }
             let commit_msg = template.render(pkg.config.post_release_commit_message());
 
             if ws_config.consolidate_commits() {


### PR DESCRIPTION
Similarly to `pre-release-replacements` applied prior to committing the release, add `post-release-replacements`.

*Motivation:*
I found myself unable to both have a "clean" release changelog (i.e. no mentioning of "under development") but still have a temporary section in the changelog afterwards in my development branch.

The solution was to add a `post-release-replacement` that behaves just like `pre-release-replacment` with the exception that it is always applied to post-release commit.