### PR TITLE
Add levels increment alphaMinor and alphaMajor 

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -20,9 +20,11 @@
   * Otherwise, bump the patch field (0.1.0 -> 0.1.1)
 * `minor`: Bump minor version (0.1.0-pre -> 0.2.0)
 * `major`: Bump major version (0.1.0-pre -> 1.0.0)
-* `alpha`, `beta`, and `rc`: Add/increment pre-release to your version
+* `alpha`, `beta`, and `rc`: Increment pre-release to your version, or add pre-release **and** bump the patch field  
   (1.0.0 -> 1.0.1-rc.1, 1.0.1-dev -> 1.0.1-rc.1, 1.0.1-rc.1 ->
   1.0.1-rc.2)
+* `alphaMinor`: Increment alpha pre-release to your version, or add alpha pre-release **and** bump the minor field
+* `alphaMajor`: Increment alpha pre-release to your version, or add alpha pre-release **and** bump the major field
 * *[version]*: bump version to given version. The version has to
   be a valid semver string and greater than current version as in
   semver spec.

--- a/src/main.rs
+++ b/src/main.rs
@@ -851,7 +851,7 @@ struct ReleaseOpt {
     #[structopt(flatten)]
     workspace: clap_cargo::Workspace,
 
-    /// Release level or version: bumping specified version field or remove prerelease extensions by default. Possible level value: major, minor, patch, release, rc, beta, alpha or any valid semver version that is greater than current version
+    /// Release level or version: bumping specified version field or remove prerelease extensions by default. Possible level value: major, minor, patch, release, rc, beta, alphaMajor, alphaMinor, alpha or any valid semver version that is greater than current version
     #[structopt(case_insensitive(true), default_value = "release")]
     level_or_version: String,
 


### PR DESCRIPTION
It is frequent to go through alpha pre-releases to test a new minor or major version.

If I want to start the test campaign for the `2.0.0` version of my project currently in `1.4.2` I have to specify by hand the name of the new version with its alpha suffix, it's a pity.

The `alphaMajor` level solves this problem.