### PR TITLE
fix(replace): More compact diff in dry-run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,10 +125,11 @@ dependencies = [
  "clap",
  "clap-cargo",
  "crates-index",
- "difference",
+ "difflib",
  "dirs",
  "env_logger",
  "ignore",
+ "itertools",
  "log",
  "maplit",
  "once_cell",
@@ -263,6 +264,12 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dirs"
@@ -452,6 +459,15 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ maplit = "1.0"
 chrono = "0.4"
 dirs = "2.0"
 boolinator = "2.4"
-difference = "2.0"
+difflib = "0.4"
+itertools = "0.9"
 once_cell = "1.2.0"
 structopt = {version = "0.3.0", default-features = false}
 clap = { version = "2", default-features = false }


### PR DESCRIPTION
Using `difference`, we show the entire file, with a character
highlighting adds/reoves and colored output.  For CHANGELOG.md and
lib.rs, these can be quite large, requiring scrolling around to double
check the content.

This switches us to reporting a unified diff, giving the users only what
changed at the cost of
- No coloring.  Could be added in the future
- No context.  The user sees the line number for what changed but thats
  it.

From a run of `cargo release` with unified diffs:
```
[2020-11-24T14:01:42Z DEBUG] Substituting values for /Users/edpage/src/personal/assert_cmd/CHANGELOG.md
[2020-11-24T14:01:42Z TRACE] Change:
    --- CHANGELOG.md    original
    +++ CHANGELOG.md    replaced
    @@ -8,0 +9 @@
    +## [1.0.3] - 2020-11-24
    @@ -220,2 +221,3 @@
    -[Unreleased]: https://github.com/assert-rs/predicates-rs/compare/v1.0.2...HEAD
    -[1.0.2]: https://github.com/assert-rs/assert_cmd/compare/v1.0.1...v1.0.2
    +[Unreleased]: https://github.com/assert-rs/predicates-rs/compare/v1.0.3...HEAD
    +[1.0.3]: https://github.com/assert-rs/predicates-rs/compare/v1.0.2...v1.0.3
    +[1.0.2]: https://github.com/assert-rs/assert_cmd/compare/v1.0.1...v1.0.2

[2020-11-24T14:01:42Z DEBUG] Substituting values for /Users/edpage/src/personal/assert_cmd/README.md
[2020-11-24T14:01:42Z TRACE] Change:
    --- README.md       original
    +++ README.md       replaced
    @@ -20 +20 @@
    -assert_cmd = "1.0.2"
    +assert_cmd = "1.0.3"

[2020-11-24T14:01:42Z DEBUG] Substituting values for /Users/edpage/src/personal/assert_cmd/src/lib.rs
[2020-11-24T14:01:42Z TRACE] Change:
    --- src/lib.rs      original
    +++ src/lib.rs      replaced
    @@ -9 +9 @@
    -//! assert_cmd = "1.0.2"
    +//! assert_cmd = "1.0.3"
```