### PR TITLE
chore: Upgrade small dep breakages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "assert_fs"
-version = "0.13.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815b47a19f74a89ba726736cdac88c9fba28a655b16ea01225adae328b26f1bf"
+checksum = "04dabd011e19821a348abb0dec7b7fda959cd6b3477c474395b958b291942b0e"
 dependencies = [
  "doc-comment",
  "globwalk",
@@ -203,16 +203,16 @@ dependencies = [
 
 [[package]]
 name = "crates-index"
-version = "0.15.5"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f0e500a0b1583ebda2cc2231804ee0d2c1943ae3225fe92530f8419a2fd96b"
+checksum = "7f24823d553339d125040d989d2a593a01b034fe5ac17714423bcd2c3d168878"
 dependencies = [
  "git2",
  "glob",
  "hex",
  "home",
  "memchr",
- "semver 0.10.0",
+ "semver 0.11.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -277,9 +277,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime",
@@ -406,12 +406,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "idna"
@@ -608,6 +605,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "quick-error"
-version = "1.2.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 
 [[package]]
 name = "quote"
@@ -816,11 +822,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.7.0",
+ "semver-parser 0.10.1",
 ]
 
 [[package]]
@@ -834,6 +840,15 @@ name = "semver-parser"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b46e1121e8180c12ff69a742aabc4f310542b6ccb69f1691689ac17fdf8618aa"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1001,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f53b1aca7d5fe2e17498a38cac0e1f5a33234d5b980fb36b9402bb93b98ae4"
+checksum = "09391a441b373597cf0888d2b052dcf82c5be4fee05da3636ae30fb57aad8484"
 dependencies = [
  "chrono",
  "combine",
@@ -1015,6 +1030,12 @@ name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ edition = "2018"
 
 [dependencies]
 cargo_metadata = "0.9"
-crates-index = "0.15"
+crates-index = "0.16"
 toml = {version = "0.5", default-features = false}
-toml_edit = "0.1"
+toml_edit = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 semver = "0.9.0"
 semver-parser = "0.9.0"
-quick-error = "1.1.0"
+quick-error = "2.0"
 regex = "1.0"
 bstr = "0.2.8"
 ignore = "0.4"
@@ -34,10 +34,10 @@ structopt = {version = "0.3.0", default-features = false}
 clap = { version = "2", default-features = false }
 clap-cargo = { version = "0.3", features = ["cargo_metadata"] }
 log = "0.4"
-env_logger = "0.7"
+env_logger = "0.8"
 
 [dev-dependencies]
-assert_fs = "0.13"
+assert_fs = "1.0"
 predicates = "1.0"
 
 [badges]

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ quick_error! {
     pub enum FatalError {
         IOError(err: IOError) {
             from()
-            cause(err)
+            source(err)
             display("IO Error: {}", err)
         }
         FileNotFound(filename: PathBuf){
@@ -24,39 +24,39 @@ quick_error! {
         InvalidCargoFileFormat(err: TomlError) {
             display("Invalid TOML file format: {}", err)
             from()
-            cause(err)
+            source(err)
         }
         InvalidCargoFileFormat2(err: TomlEditError) {
             display("Invalid TOML file format: {}", err)
             from()
-            cause(err)
+            source(err)
         }
         InvalidCargoFileFormat3(err: CargoMetaError) {
             display("Invalid TOML file format: {}", err)
             from()
-            cause(err)
+            source(err)
         }
         InvalidCargoConfigKeys {
             display("Invalid cargo-release config item found")
         }
         SemVerError(err: SemVerError) {
             from()
-            cause(err)
+            source(err)
             display("SemVerError {}", err)
         }
         IgnoreError(err: ignore::Error) {
             from()
-            cause(err)
+            source(err)
             display("ignore-pattern {}", err)
         }
         Utf8Error(err: Utf8Error) {
             from()
-            cause(err)
+            source(err)
             display("Utf8Error {}", err)
         }
         FromUtf8Error(err: FromUtf8Error) {
             from()
-            cause(err)
+            source(err)
             display("FromUtf8Error {}", err)
         }
         NoPackage {
@@ -77,7 +77,7 @@ quick_error! {
         }
         ReplacerRegexError(err: RegexError) {
             from()
-            cause(err)
+            source(err)
             display("RegexError {}", err)
         }
         ReplacerMinError(pattern: String, req: usize, actual: usize) {
@@ -88,7 +88,7 @@ quick_error! {
         }
         VarError(err: VarError) {
             from()
-            cause(err)
+            source(err)
             display("Environment Variable Error: {}", err)
         }
         GitError {


### PR DESCRIPTION
Things left out
- semver is coupled to cargo-metadata which is coupled which is cupled
  to clap-cargo
- semver-parser completely changed its API, being higher level than
  before which makes our job harder to make tweaks to existing version
  ranges.