### PR TITLE
add small thread sleep between publishes - for #224

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -702,8 +702,8 @@ fn release_packages<'m>(
 
             if pkg.config.registry().is_none() {
                 cargo::wait_for_publish(crate_name, &base.version_string, timeout, dry_run)?;
-                // give crates a little leeway to propagate a successful publish
-                // this should avoid failed to select failures where the next pkg in line depends on the previous
+                // HACK: Even once the index is updated, there seems to be another step before the publish is fully ready.
+                // We don't have a way yet to check for that, so waiting for now in hopes everything is ready
                 std::time::Duration::from_secs(5);
             } else {
                 log::debug!("Not waiting for publish because the registry is not crates.io and doesn't get updated automatically");

--- a/src/main.rs
+++ b/src/main.rs
@@ -702,6 +702,9 @@ fn release_packages<'m>(
 
             if pkg.config.registry().is_none() {
                 cargo::wait_for_publish(crate_name, &base.version_string, timeout, dry_run)?;
+                // give crates a little leeway to propagate a successful publish
+                // this should avoid failed to select failures where the next pkg in line depends on the previous
+                std::time::Duration::from_secs(5);
             } else {
                 log::debug!("Not waiting for publish because the registry is not crates.io and doesn't get updated automatically");
             }


### PR DESCRIPTION
Hey all. Thank you for cargo-release. It's very helpful!
This particular issue (#224) keeps biting me, and while this PR has only a dumb/ugly solution, I do think it should fix the problem. If the chosen time is bad, we could parametrise the second value into argv.

(it's probably possible to write a more advanced solution with a curl to crates.io to check that the previous upload has completed, but I'm not even sure that's perfect if all that's happening under the hood is that the write operation (the publish) propagates to all of crates' replicas.)
