### PR TITLE
fix sleep after publish (call sleep) for #224;

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -704,7 +704,7 @@ fn release_packages<'m>(
                 cargo::wait_for_publish(crate_name, &base.version_string, timeout, dry_run)?;
                 // HACK: Even once the index is updated, there seems to be another step before the publish is fully ready.
                 // We don't have a way yet to check for that, so waiting for now in hopes everything is ready
-                std::time::Duration::from_secs(5);
+                std::thread::sleep(std::time::Duration::from_secs(5));
             } else {
                 log::debug!("Not waiting for publish because the registry is not crates.io and doesn't get updated automatically");
             }


### PR DESCRIPTION
Ref #224
Seems like in #247 a call to `sleep` was missing. 