### PR TITLE
Allow to set the time waited between two cargo publishs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### Added
 
-* Add `--publish-grace-sleep` parameter that allows to set the number of seconds to sleep between
-  two invocations of `cargo publish`
+* Add `PUBLISH_GRACE_SLEEP` environment variable that allows to set the number of seconds to sleep between
+  two invocations of `cargo publish`. Default is `5`
 * Do not sleep between publishes on dry runs
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+* Add `--publish-grace-sleep` parameter that allows to set the number of seconds to sleep between
+  two invocations of `cargo publish`
+* Do not sleep between publishes on dry runs
+
 ### Changed
 
 * New `diable-release` config flag to skip crates in a workspace

--- a/src/main.rs
+++ b/src/main.rs
@@ -710,6 +710,7 @@ fn release_packages<'m>(
                 // HACK: Even once the index is updated, there seems to be another step before the publish is fully ready.
                 // We don't have a way yet to check for that, so waiting for now in hopes everything is ready
                 if !dry_run {
+                    log::info!("Waiting an additional {} seconds for crates.io to update its indices...", args.config.publish_grace_sleep);
                     std::thread::sleep(std::time::Duration::from_secs(args.config.publish_grace_sleep));
                 }
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -709,7 +709,7 @@ fn release_packages<'m>(
                 cargo::wait_for_publish(crate_name, &base.version_string, timeout, dry_run)?;
                 // HACK: Even once the index is updated, there seems to be another step before the publish is fully ready.
                 // We don't have a way yet to check for that, so waiting for now in hopes everything is ready
-                std::thread::sleep(std::time::Duration::from_secs(5));
+                std::thread::sleep(std::time::Duration::from_secs(60));
             } else {
                 log::debug!("Not waiting for publish because the registry is not crates.io and doesn't get updated automatically");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -709,7 +709,9 @@ fn release_packages<'m>(
                 cargo::wait_for_publish(crate_name, &base.version_string, timeout, dry_run)?;
                 // HACK: Even once the index is updated, there seems to be another step before the publish is fully ready.
                 // We don't have a way yet to check for that, so waiting for now in hopes everything is ready
-                std::thread::sleep(std::time::Duration::from_secs(60));
+                if !dry_run {
+                    std::thread::sleep(std::time::Duration::from_secs(args.config.publish_grace_sleep));
+                }
             } else {
                 log::debug!("Not waiting for publish because the registry is not crates.io and doesn't get updated automatically");
             }
@@ -992,6 +994,10 @@ struct ConfigArgs {
     #[structopt(long)]
     /// Token to use when uploading
     token: Option<String>,
+
+    #[structopt(long, default_value = "5")]
+    /// Number of seconds that we sleep between two invocations of cargo publish
+    publish_grace_sleep: u64,
 }
 
 impl config::ConfigSource for ConfigArgs {

--- a/src/main.rs
+++ b/src/main.rs
@@ -710,8 +710,9 @@ fn release_packages<'m>(
                 // HACK: Even once the index is updated, there seems to be another step before the publish is fully ready.
                 // We don't have a way yet to check for that, so waiting for now in hopes everything is ready
                 if !dry_run {
-                    log::info!("Waiting an additional {} seconds for crates.io to update its indices...", args.config.publish_grace_sleep);
-                    std::thread::sleep(std::time::Duration::from_secs(args.config.publish_grace_sleep));
+                    let publish_grace_sleep = std::env::var("PUBLISH_GRACE_SLEEP").unwrap_or("5".to_owned()).parse().unwrap_or(5);
+                    log::info!("Waiting an additional {} seconds for crates.io to update its indices...", publish_grace_sleep);
+                    std::thread::sleep(std::time::Duration::from_secs(publish_grace_sleep));
                 }
             } else {
                 log::debug!("Not waiting for publish because the registry is not crates.io and doesn't get updated automatically");
@@ -995,10 +996,6 @@ struct ConfigArgs {
     #[structopt(long)]
     /// Token to use when uploading
     token: Option<String>,
-
-    #[structopt(long, default_value = "5")]
-    /// Number of seconds that we sleep between two invocations of cargo publish
-    publish_grace_sleep: u64,
 }
 
 impl config::ConfigSource for ConfigArgs {

--- a/src/main.rs
+++ b/src/main.rs
@@ -710,8 +710,14 @@ fn release_packages<'m>(
                 // HACK: Even once the index is updated, there seems to be another step before the publish is fully ready.
                 // We don't have a way yet to check for that, so waiting for now in hopes everything is ready
                 if !dry_run {
-                    let publish_grace_sleep = std::env::var("PUBLISH_GRACE_SLEEP").unwrap_or("5".to_owned()).parse().unwrap_or(5);
-                    log::info!("Waiting an additional {} seconds for crates.io to update its indices...", publish_grace_sleep);
+                    let publish_grace_sleep = std::env::var("PUBLISH_GRACE_SLEEP")
+                        .unwrap_or("5".to_owned())
+                        .parse()
+                        .unwrap_or(5);
+                    log::info!(
+                        "Waiting an additional {} seconds for crates.io to update its indices...",
+                        publish_grace_sleep
+                    );
                     std::thread::sleep(std::time::Duration::from_secs(publish_grace_sleep));
                 }
             } else {


### PR DESCRIPTION
This adds a command line parameter `--publish-grace-sleep` that defines how long we wait between two invocations of `cargo publish`. The default value is 5.