### PR TITLE
fix(git)!: Dealing with the remote is workspace-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+* `disable-push`, `push-remote` now only apply at the workspace level, when in a workspace.
+
 ## [0.14.0] - 2021-06-16
 
 ### Added


### PR DESCRIPTION
No idea how this will interact with #263 but this will help with
implementing #266.

BREAKING CHANGE: When in a workspace, we'll now only look at the
workspace's config for `disable-push` and `push-remote` and no the
package-specific config.