### PR TITLE
feat(git): Support push-options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+* `push-options` to send flags to the server, on push.  Current limitations include:
+  * Only on branch and not tag push
+  * Operates at the workspace level
+  * No placeholders are supported
+
 ### Changed
 
 * `disable-push`, `push-remote` now only apply at the workspace level, when in a workspace.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -52,6 +52,7 @@ Configuration is read from the following (in precedence order)
 | `registry`     | `--registry`    | string | Cargo registry name to publish to (default uses Rust's default, which goes to `crates.io`) |
 | `disable-release` | `--exclude`  | bool   | Skip the entire release process (usually for internal crates in a workspace) |
 | `disable-push` | `--skip-push`   | bool   | Don't do git push |
+| `push-options` | \-              | list of strings | Flags to send to the server when doing a `git push` |
 | `disable-tag`  | `--skip-tag`    | bool   | Don't do git tag |
 | `disable-publish` | `--skip-publish` |  bool | Don't do cargo publish right now, see [manifest `publish` field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish--field-optional) to permanently disable publish. |
 | `consolidate-commits` | \- | bool | When releasing a workspace, use a single commit for the pre-release version bump and a single commit for the post-release version bump. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,10 @@ pub trait ConfigSource {
         None
     }
 
+    fn push_options(&self) -> Option<&[String]> {
+        None
+    }
+
     fn dev_version_ext(&self) -> Option<&str> {
         None
     }
@@ -118,6 +122,7 @@ pub struct Config {
     pub disable_release: Option<bool>,
     pub disable_publish: Option<bool>,
     pub disable_push: Option<bool>,
+    pub push_options: Option<Vec<String>>,
     pub dev_version_ext: Option<String>,
     pub no_dev_version: Option<bool>,
     pub consolidate_commits: Option<bool>,
@@ -162,6 +167,9 @@ impl Config {
         }
         if let Some(disable_push) = source.disable_push() {
             self.disable_push = Some(disable_push);
+        }
+        if let Some(push_options) = source.push_options() {
+            self.push_options = Some(push_options.to_owned());
         }
         if let Some(dev_version_ext) = source.dev_version_ext() {
             self.dev_version_ext = Some(dev_version_ext.to_owned());
@@ -250,6 +258,13 @@ impl Config {
 
     pub fn disable_push(&self) -> bool {
         self.disable_push.unwrap_or(false)
+    }
+
+    pub fn push_options(&self) -> &[String] {
+        self.push_options
+            .as_ref()
+            .map(|v| v.as_ref())
+            .unwrap_or(&[])
     }
 
     pub fn dev_version_ext(&self) -> &str {
@@ -372,6 +387,10 @@ impl ConfigSource for Config {
 
     fn disable_push(&self) -> Option<bool> {
         self.disable_push
+    }
+
+    fn push_options(&self) -> Option<&[String]> {
+        self.push_options.as_ref().map(|v| v.as_ref())
     }
 
     fn dev_version_ext(&self) -> Option<&str> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -132,8 +132,19 @@ pub fn tag(
     )
 }
 
-pub fn push(dir: &Path, remote: &str, dry_run: bool) -> Result<bool, FatalError> {
-    call_on_path(vec!["git", "push", remote], dir, dry_run)
+pub fn push(
+    dir: &Path,
+    remote: &str,
+    options: &[String],
+    dry_run: bool,
+) -> Result<bool, FatalError> {
+    let mut command = vec!["git", "push"];
+    for option in options {
+        command.push("--push-option");
+        command.push(option.as_str());
+    }
+    command.push(remote);
+    call_on_path(command, dir, dry_run)
 }
 
 pub fn push_tag(dir: &Path, remote: &str, tag: &str, dry_run: bool) -> Result<bool, FatalError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -849,7 +849,12 @@ fn release_packages<'m>(
         }
 
         log::info!("Pushing HEAD to {}", git_remote);
-        if !git::push(&ws_meta.workspace_root, git_remote, dry_run)? {
+        if !git::push(
+            &ws_meta.workspace_root,
+            git_remote,
+            ws_config.push_options(),
+            dry_run,
+        )? {
             return Ok(106);
         }
     }


### PR DESCRIPTION
This helps when users want to customize CI behavior.

Current limitations include:
  * Only on branch and not tag push
  * Operates at the workspace level
  * No placeholders are supported

Fixes #266