### PR TITLE
Make code base clippy-happy

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -68,11 +68,8 @@ pub fn wait_for_publish(
         let index = crates_index::Index::new_cargo_default();
         let mut logged = false;
         loop {
-            match index.update() {
-                Err(e) => {
-                    log::debug!("Crate index update failed with {}", e);
-                }
-                _ => (),
+            if let Err(e) = index.update() {
+                log::debug!("Crate index update failed with {}", e);
             }
             let crate_data = index.crate_(name);
             let published = crate_data

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -78,8 +78,7 @@ pub fn wait_for_publish(
             let published = crate_data
                 .iter()
                 .flat_map(|c| c.versions().iter())
-                .find(|v| v.version() == version)
-                .is_some();
+                .any(|v| v.version() == version);
 
             if published {
                 break;

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -189,7 +189,7 @@ pub fn update_lock(manifest_path: &Path) -> Result<(), FatalError> {
 }
 
 pub fn parse_cargo_config(manifest_path: &Path) -> Result<Value, FatalError> {
-    let cargo_file_content = load_from_file(&manifest_path).map_err(FatalError::from)?;
+    let cargo_file_content = load_from_file(manifest_path).map_err(FatalError::from)?;
     cargo_file_content.parse().map_err(FatalError::from)
 }
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -200,7 +200,6 @@ fn load_from_file(path: &Path) -> io::Result<String> {
 mod test {
     use super::*;
 
-    use assert_fs;
     #[allow(unused_imports)] // Not being detected
     use assert_fs::prelude::*;
     use predicates::prelude::*;

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
+use clap::arg_enum;
 use serde::{Deserialize, Serialize};
 
 use crate::error::FatalError;

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,14 +238,11 @@ impl Config {
     }
 
     pub fn push_remote(&self) -> &str {
-        self.push_remote
-            .as_ref()
-            .map(|s| s.as_str())
-            .unwrap_or("origin")
+        self.push_remote.as_deref().unwrap_or("origin")
     }
 
     pub fn registry(&self) -> Option<&str> {
-        self.registry.as_ref().map(|s| s.as_str())
+        self.registry.as_deref()
     }
 
     pub fn disable_release(&self) -> bool {
@@ -268,10 +265,7 @@ impl Config {
     }
 
     pub fn dev_version_ext(&self) -> &str {
-        self.dev_version_ext
-            .as_ref()
-            .map(|s| s.as_str())
-            .unwrap_or("alpha.0")
+        self.dev_version_ext.as_deref().unwrap_or("alpha.0")
     }
 
     pub fn no_dev_version(&self) -> bool {
@@ -284,15 +278,13 @@ impl Config {
 
     pub fn pre_release_commit_message(&self) -> &str {
         self.pre_release_commit_message
-            .as_ref()
-            .map(|s| s.as_str())
+            .as_deref()
             .unwrap_or("(cargo-release) version {{version}}")
     }
 
     pub fn post_release_commit_message(&self) -> &str {
         self.post_release_commit_message
-            .as_ref()
-            .map(|s| s.as_str())
+            .as_deref()
             .unwrap_or("(cargo-release) start next development iteration {{next_version}}")
     }
 
@@ -316,24 +308,19 @@ impl Config {
 
     pub fn tag_message(&self) -> &str {
         self.tag_message
-            .as_ref()
-            .map(|s| s.as_str())
+            .as_deref()
             .unwrap_or("(cargo-release) {{crate_name}} version {{version}}")
     }
 
     pub fn tag_prefix(&self, is_root: bool) -> &str {
         // crate_name as default tag prefix for multi-crate project
         self.tag_prefix
-            .as_ref()
-            .map(|s| s.as_str())
+            .as_deref()
             .unwrap_or_else(|| if !is_root { "{{crate_name}}-" } else { "" })
     }
 
     pub fn tag_name(&self) -> &str {
-        self.tag_name
-            .as_ref()
-            .map(|s| s.as_str())
-            .unwrap_or("{{prefix}}v{{version}}")
+        self.tag_name.as_deref().unwrap_or("{{prefix}}v{{version}}")
     }
 
     pub fn disable_tag(&self) -> bool {
@@ -370,11 +357,11 @@ impl ConfigSource for Config {
     }
 
     fn push_remote(&self) -> Option<&str> {
-        self.push_remote.as_ref().map(|s| s.as_str())
+        self.push_remote.as_deref()
     }
 
     fn registry(&self) -> Option<&str> {
-        self.registry.as_ref().map(|s| s.as_str())
+        self.registry.as_deref()
     }
 
     fn disable_release(&self) -> Option<bool> {
@@ -394,7 +381,7 @@ impl ConfigSource for Config {
     }
 
     fn dev_version_ext(&self) -> Option<&str> {
-        self.dev_version_ext.as_ref().map(|s| s.as_str())
+        self.dev_version_ext.as_deref()
     }
 
     fn no_dev_version(&self) -> Option<bool> {
@@ -406,18 +393,16 @@ impl ConfigSource for Config {
     }
 
     fn pre_release_commit_message(&self) -> Option<&str> {
-        self.pre_release_commit_message.as_ref().map(|s| s.as_str())
+        self.pre_release_commit_message.as_deref()
     }
 
     // deprecated
     fn pro_release_commit_message(&self) -> Option<&str> {
-        self.pro_release_commit_message.as_ref().map(|s| s.as_str())
+        self.pro_release_commit_message.as_deref()
     }
 
     fn post_release_commit_message(&self) -> Option<&str> {
-        self.post_release_commit_message
-            .as_ref()
-            .map(|s| s.as_str())
+        self.post_release_commit_message.as_deref()
     }
 
     fn pre_release_replacements(&self) -> Option<&[Replace]> {
@@ -433,15 +418,15 @@ impl ConfigSource for Config {
     }
 
     fn tag_message(&self) -> Option<&str> {
-        self.tag_message.as_ref().map(|s| s.as_str())
+        self.tag_message.as_deref()
     }
 
     fn tag_prefix(&self) -> Option<&str> {
-        self.tag_prefix.as_ref().map(|s| s.as_str())
+        self.tag_prefix.as_deref()
     }
 
     fn tag_name(&self) -> Option<&str> {
-        self.tag_name.as_ref().map(|s| s.as_str())
+        self.tag_name.as_deref()
     }
 
     fn disable_tag(&self) -> Option<bool> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 
 use cargo_metadata::Error as CargoMetaError;
+use quick_error::quick_error;
 use regex::Error as RegexError;
 use semver::SemVerError;
 use toml::de::Error as TomlError;

--- a/src/main.rs
+++ b/src/main.rs
@@ -621,7 +621,7 @@ fn release_packages<'m>(
                     version: Some(&new_version_string),
                     crate_name: Some(crate_name),
                     date: Some(NOW.as_str()),
-                    tag_name: pkg.tag.as_ref().map(|s| s.as_str()),
+                    tag_name: pkg.tag.as_deref(),
                     ..Default::default()
                 };
                 let prerelease = !version.version.pre.is_empty();
@@ -792,7 +792,7 @@ fn release_packages<'m>(
                 version: Some(&base.version_string),
                 crate_name: Some(crate_name),
                 date: Some(NOW.as_str()),
-                tag_name: pkg.tag.as_ref().map(|s| s.as_str()),
+                tag_name: pkg.tag.as_deref(),
                 next_version: Some(updated_version_string),
                 ..Default::default()
             };
@@ -1025,11 +1025,11 @@ impl config::ConfigSource for ConfigArgs {
     }
 
     fn push_remote(&self) -> Option<&str> {
-        self.push_remote.as_ref().map(|s| s.as_str())
+        self.push_remote.as_deref()
     }
 
     fn registry(&self) -> Option<&str> {
-        self.registry.as_ref().map(|s| s.as_str())
+        self.registry.as_deref()
     }
 
     fn disable_publish(&self) -> Option<bool> {
@@ -1041,7 +1041,7 @@ impl config::ConfigSource for ConfigArgs {
     }
 
     fn dev_version_ext(&self) -> Option<&str> {
-        self.dev_version_ext.as_ref().map(|s| s.as_str())
+        self.dev_version_ext.as_deref()
     }
 
     fn no_dev_version(&self) -> Option<bool> {
@@ -1049,11 +1049,11 @@ impl config::ConfigSource for ConfigArgs {
     }
 
     fn tag_prefix(&self) -> Option<&str> {
-        self.tag_prefix.as_ref().map(|s| s.as_str())
+        self.tag_prefix.as_deref()
     }
 
     fn tag_name(&self) -> Option<&str> {
-        self.tag_name.as_ref().map(|s| s.as_str())
+        self.tag_name.as_deref()
     }
 
     fn disable_tag(&self) -> Option<bool> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,7 +294,7 @@ impl<'m> PackageRelease<'m> {
             post_version,
             dependents,
 
-            features: features,
+            features,
         };
         Ok(Some(pkg))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,3 @@
-#[macro_use]
-extern crate clap;
-#[macro_use]
-extern crate maplit;
-#[macro_use]
-extern crate quick_error;
-
-#[cfg(test)]
-extern crate assert_fs;
-
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::OsStr;
@@ -633,7 +623,7 @@ fn release_packages<'m>(
             if let Some(pre_rel_hook) = pkg.config.pre_release_hook() {
                 let pre_rel_hook = pre_rel_hook.args();
                 log::debug!("Calling pre-release hook: {:?}", pre_rel_hook);
-                let envs = btreemap! {
+                let envs = maplit::btreemap! {
                     OsStr::new("PREV_VERSION") => pkg.prev_version.version_string.as_ref(),
                     OsStr::new("NEW_VERSION") => new_version_string.as_ref(),
                     OsStr::new("DRY_RUN") => OsStr::new(if dry_run { "true" } else { "false" }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,6 @@ extern crate maplit;
 #[macro_use]
 extern crate quick_error;
 
-use structopt;
-
 #[cfg(test)]
 extern crate assert_fs;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -437,7 +437,7 @@ fn release_workspace(args: &ReleaseOpt) -> Result<i32, error::FatalError> {
     release_packages(args, &ws_meta, &ws_config, pkg_releases.as_slice())
 }
 
-fn sort_workspace<'m>(ws_meta: &'m cargo_metadata::Metadata) -> Vec<&'m cargo_metadata::PackageId> {
+fn sort_workspace(ws_meta: &cargo_metadata::Metadata) -> Vec<&cargo_metadata::PackageId> {
     let members: HashSet<_> = ws_meta.workspace_members.iter().collect();
     let dep_tree: HashMap<_, _> = ws_meta
         .resolve

--- a/src/main.rs
+++ b/src/main.rs
@@ -503,11 +503,8 @@ fn release_packages<'m>(
                 let mut changed: Vec<_> = changed
                     .into_iter()
                     .filter(|p| {
-                        let file_in_subcrate = pkg
-                            .crate_excludes
-                            .iter()
-                            .find(|base| p.starts_with(base))
-                            .is_some();
+                        let file_in_subcrate =
+                            pkg.crate_excludes.iter().any(|base| p.starts_with(base));
                         if file_in_subcrate {
                             return false;
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,20 +206,20 @@ impl<'m> PackageRelease<'m> {
                 }
             } else {
                 // given version
-                let new_version =
-                    semver::Version::parse(&args.level_or_version).map_err(FatalError::from)?;
-                if new_version > potential_version {
-                    is_pre_release = new_version.is_prerelease();
-                    Some(Version {
-                        version: new_version,
-                        version_string: args.level_or_version.to_owned(),
-                    })
-                } else if new_version == potential_version {
-                    None
-                } else {
-                    return Err(error::FatalError::UnsupportedVersionReq(
-                        "Cannot release version smaller than current one".to_owned(),
-                    ));
+                match semver::Version::parse(&args.level_or_version)? {
+                    version if version > potential_version => {
+                        is_pre_release = version.is_prerelease();
+                        Some(Version {
+                            version,
+                            version_string: args.level_or_version.to_owned(),
+                        })
+                    }
+                    version if version == potential_version => None,
+                    _ => {
+                        return Err(error::FatalError::UnsupportedVersionReq(
+                            "Cannot release version smaller than current one".to_owned(),
+                        ));
+                    }
                 }
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -721,7 +721,7 @@ fn release_packages<'m>(
                 // We don't have a way yet to check for that, so waiting for now in hopes everything is ready
                 if !dry_run {
                     let publish_grace_sleep = std::env::var("PUBLISH_GRACE_SLEEP")
-                        .unwrap_or("5".to_owned())
+                        .unwrap_or_else(|_| String::from("5"))
                         .parse()
                         .unwrap_or(5);
                     log::info!(
@@ -1017,11 +1017,15 @@ struct ConfigArgs {
 
 impl config::ConfigSource for ConfigArgs {
     fn sign_commit(&self) -> Option<bool> {
-        self.sign.as_some(true).or(self.sign_commit.as_some(true))
+        self.sign
+            .as_some(true)
+            .or_else(|| self.sign_commit.as_some(true))
     }
 
     fn sign_tag(&self) -> Option<bool> {
-        self.sign.as_some(true).or(self.sign_tag.as_some(true))
+        self.sign
+            .as_some(true)
+            .or_else(|| self.sign_tag.as_some(true))
     }
 
     fn push_remote(&self) -> Option<&str> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,7 +233,7 @@ impl<'m> PackageRelease<'m> {
             Vec::new()
         };
 
-        let base = version.as_ref().unwrap_or_else(|| &prev_version);
+        let base = version.as_ref().unwrap_or(&prev_version);
 
         let tag = if config.disable_tag() {
             None
@@ -574,14 +574,14 @@ fn release_packages<'m>(
         let prompt = if pkgs.len() == 1 {
             let pkg = pkgs[0];
             let crate_name = pkg.meta.name.as_str();
-            let base = pkg.version.as_ref().unwrap_or_else(|| &pkg.prev_version);
+            let base = pkg.version.as_ref().unwrap_or(&pkg.prev_version);
             format!("Release {} {}?", crate_name, base.version_string)
         } else {
             let mut buffer: Vec<u8> = vec![];
             writeln!(&mut buffer, "Release").unwrap();
             for pkg in pkgs {
                 let crate_name = pkg.meta.name.as_str();
-                let base = pkg.version.as_ref().unwrap_or_else(|| &pkg.prev_version);
+                let base = pkg.version.as_ref().unwrap_or(&pkg.prev_version);
                 writeln!(&mut buffer, "  {} {}", crate_name, base.version_string).unwrap();
             }
             write!(&mut buffer, "?").unwrap();
@@ -699,7 +699,7 @@ fn release_packages<'m>(
     for pkg in pkgs {
         if !pkg.config.disable_publish() {
             let crate_name = pkg.meta.name.as_str();
-            let base = pkg.version.as_ref().unwrap_or_else(|| &pkg.prev_version);
+            let base = pkg.version.as_ref().unwrap_or(&pkg.prev_version);
 
             log::info!("Running cargo publish on {}", crate_name);
             // feature list to release
@@ -749,7 +749,7 @@ fn release_packages<'m>(
             let cwd = pkg.package_path;
             let crate_name = pkg.meta.name.as_str();
 
-            let base = pkg.version.as_ref().unwrap_or_else(|| &pkg.prev_version);
+            let base = pkg.version.as_ref().unwrap_or(&pkg.prev_version);
             let template = Template {
                 prev_version: Some(&pkg.prev_version.version_string),
                 version: Some(&base.version_string),
@@ -786,7 +786,7 @@ fn release_packages<'m>(
                 cargo::set_package_version(pkg.manifest_path, updated_version_string)?;
                 cargo::update_lock(pkg.manifest_path)?;
             }
-            let base = pkg.version.as_ref().unwrap_or_else(|| &pkg.prev_version);
+            let base = pkg.version.as_ref().unwrap_or(&pkg.prev_version);
             let template = Template {
                 prev_version: Some(&pkg.prev_version.version_string),
                 version: Some(&base.version_string),

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -58,10 +58,7 @@ pub fn do_file_replacements(
     let mut by_file = BTreeMap::new();
     for replace in replace_config {
         let file = replace.file.clone();
-        by_file
-            .entry(file)
-            .or_insert_with(|| Vec::new())
-            .push(replace);
+        by_file.entry(file).or_insert_with(Vec::new).push(replace);
     }
 
     for (path, replaces) in by_file.into_iter() {

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -87,13 +87,13 @@ pub fn do_file_replacements(
                     pattern.to_owned(),
                     min,
                     actual,
-                ))?;
+                ));
             } else if max < actual {
                 return Err(FatalError::ReplacerMaxError(
                     pattern.to_owned(),
                     min,
                     actual,
-                ))?;
+                ));
             }
 
             let to_replace = replace.replace.as_str();

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,3 +1,4 @@
+use clap::arg_enum;
 use semver::{Identifier, Version};
 
 use crate::error::FatalError;

--- a/src/version.rs
+++ b/src/version.rs
@@ -301,7 +301,7 @@ mod display {
             if self.0.predicates.is_empty() {
                 write!(fmt, "*")?;
             } else {
-                for (i, ref pred) in self.0.predicates.iter().enumerate() {
+                for (i, pred) in self.0.predicates.iter().enumerate() {
                     if i == 0 {
                         write!(fmt, "{}", DisplayPredicate(pred))?;
                     } else {

--- a/src/version.rs
+++ b/src/version.rs
@@ -21,10 +21,7 @@ arg_enum! {
 
 impl BumpLevel {
     pub fn is_pre_release(self) -> bool {
-        match self {
-            BumpLevel::Alpha | BumpLevel::Beta | BumpLevel::Rc => true,
-            _ => false,
-        }
+        matches!(self, BumpLevel::Alpha | BumpLevel::Beta | BumpLevel::Rc)
     }
 
     pub fn bump_version(

--- a/src/version.rs
+++ b/src/version.rs
@@ -464,7 +464,7 @@ mod test {
             let req = semver::VersionReq::parse(req).unwrap();
             let actual = set_requirement(&req, &version).unwrap();
             let expected = expected.into();
-            assert_eq!(actual.as_ref().map(|s| s.as_str()), expected);
+            assert_eq!(actual.as_deref(), expected);
         }
 
         #[test]

--- a/src/version.rs
+++ b/src/version.rs
@@ -2,9 +2,9 @@ use semver::{Identifier, Version};
 
 use crate::error::FatalError;
 
-static VERSION_ALPHA: &'static str = "alpha";
-static VERSION_BETA: &'static str = "beta";
-static VERSION_RC: &'static str = "rc";
+static VERSION_ALPHA: &str = "alpha";
+static VERSION_BETA: &str = "beta";
+static VERSION_RC: &str = "rc";
 
 arg_enum! {
     #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
This PR cleans up clippy warnings. Each commit addresses a specific clippy lint in the entire codebase, to facilitate ease of review. The changes themselves should be pretty much non-controversial, but should that not be the case it is easy to revert independently.

Feel free to review and comment.

Addresses  #270