### PR TITLE
fix(cargo): Don't panic on unexpected Cargo.tomls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,12 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
-
-[[package]]
 name = "assert_fs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +79,12 @@ name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cargo-release"
@@ -192,15 +192,12 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "3.8.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+checksum = "a2d47c1b11006b87e492b53b313bb699ce60e16613c4dddaa91f8f7c220ab2fa"
 dependencies = [
- "ascii",
- "byteorder",
- "either",
+ "bytes",
  "memchr",
- "unreachable",
 ]
 
 [[package]]
@@ -1018,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09391a441b373597cf0888d2b052dcf82c5be4fee05da3636ae30fb57aad8484"
+checksum = "dbbdcf4f749dd33b1f1ea19b547bf789d87442ec40767d6015e5e2d39158d69a"
 dependencies = [
  "chrono",
  "combine",
@@ -1076,15 +1073,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "url"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,12 +1101,6 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 cargo_metadata = "0.9"
 crates-index = "0.16"
 toml = {version = "0.5", default-features = false}
-toml_edit = "0.2"
+toml_edit = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
 semver = "0.9.0"
 semver-parser = "0.9.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,20 +22,23 @@ quick_error! {
         FileNotFound(filename: PathBuf){
             display("Unable to find file {} to perform replace", filename.display())
         }
-        InvalidCargoFileFormat(err: TomlError) {
+        InvalidTomlFileFormat(err: TomlError) {
             display("Invalid TOML file format: {}", err)
             from()
             source(err)
         }
-        InvalidCargoFileFormat2(err: TomlEditError) {
+        InvalidTomlEditFileFormat(err: TomlEditError) {
             display("Invalid TOML file format: {}", err)
             from()
             source(err)
         }
-        InvalidCargoFileFormat3(err: CargoMetaError) {
-            display("Invalid TOML file format: {}", err)
+        InvalidCargoMetaFileFormat(err: CargoMetaError) {
+            display("Invalid Cargo file format: {}", err)
             from()
             source(err)
+        }
+        InvalidCargoFileFormat(msg: String) {
+            display("Invalid TOML file format: {}", msg)
         }
         InvalidCargoConfigKeys {
             display("Invalid cargo-release config item found")


### PR DESCRIPTION
When I first wrote this, `toml_edit`s API was more limited.  This
modernizes it to how I would write it now.  I assumed this would make it
shorter but apparently not, but I feel this clarifies intent more than
the repeated `contains_key` calls.

In refactoring this, the fix for #274 naturally fell out of it.

Fixes #274