### PR TITLE
fix(git): Read push-options for each crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+* Prior sharing of pushes between workspace crates is now behind the flag `consolidate-pushes`
+
 ## [0.15.1] - 2021-06-24
 
 ### Fixed

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -56,6 +56,7 @@ Configuration is read from the following (in precedence order)
 | `disable-tag`  | `--skip-tag`    | bool   | Don't do git tag |
 | `disable-publish` | `--skip-publish` |  bool | Don't do cargo publish right now, see [manifest `publish` field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish--field-optional) to permanently disable publish. |
 | `consolidate-commits` | \- | bool | When releasing a workspace, use a single commit for the pre-release version bump and a single commit for the post-release version bump. |
+| `consolidate-pushes` | \- | bool | When releasing a workspace, use do a single push across all crates in a workspace. |
 | `pre-release-commit-message` | \- | string | A commit message template for release. For example: `"release {{version}}"`, where `{{version}}` will be replaced by actual version. |
 | `post-release-commit-message` | \- | string | A commit message template for bumping version after release. For example: `Released {{version}}, starting {{next_version}}`. The placeholder `{{next_version}}` (the version in git after release) is supported in addition to the global placeholders mentioned below. |
 | `tag-message`  | \-              | string | A message template for tag. The placeholder `{{tag_name}}` and `{{prefix}}` (the tag prefix) is supported in addition to the global placeholders mentioned below. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,10 @@ pub trait ConfigSource {
         None
     }
 
+    fn consolidate_pushes(&self) -> Option<bool> {
+        None
+    }
+
     fn pre_release_commit_message(&self) -> Option<&str> {
         None
     }
@@ -127,6 +131,7 @@ pub struct Config {
     pub dev_version_ext: Option<String>,
     pub no_dev_version: Option<bool>,
     pub consolidate_commits: Option<bool>,
+    pub consolidate_pushes: Option<bool>,
     pub pre_release_commit_message: Option<String>,
     // depreacted
     pub pro_release_commit_message: Option<String>,
@@ -180,6 +185,9 @@ impl Config {
         }
         if let Some(consolidate_commits) = source.consolidate_commits() {
             self.consolidate_commits = Some(consolidate_commits);
+        }
+        if let Some(consolidate_pushes) = source.consolidate_pushes() {
+            self.consolidate_pushes = Some(consolidate_pushes);
         }
         if let Some(pre_release_commit_message) = source.pre_release_commit_message() {
             self.pre_release_commit_message = Some(pre_release_commit_message.to_owned());
@@ -275,6 +283,10 @@ impl Config {
 
     pub fn consolidate_commits(&self) -> bool {
         self.consolidate_commits.unwrap_or(false)
+    }
+
+    pub fn consolidate_pushes(&self) -> bool {
+        self.consolidate_pushes.unwrap_or(false)
     }
 
     pub fn pre_release_commit_message(&self) -> &str {
@@ -391,6 +403,10 @@ impl ConfigSource for Config {
 
     fn consolidate_commits(&self) -> Option<bool> {
         self.consolidate_commits
+    }
+
+    fn consolidate_pushes(&self) -> Option<bool> {
+        self.consolidate_pushes
     }
 
     fn pre_release_commit_message(&self) -> Option<&str> {


### PR DESCRIPTION
With workspaces, it was annoying to have a push per crate, so I merged
them together.  Then in #267, when implementing push options, I needed
something to read them from, so I made push config exclusively a
workspace-level features.

A better model for this is with `consolidate-commits` where people
opt-in to consolidation, and otherwise we use the crate's config.  This
will also help with #263

Fixes #269