### PR TITLE
refactor(args): Abstract level vs version args

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -21,14 +21,10 @@ arg_enum! {
 }
 
 impl BumpLevel {
-    pub fn is_pre_release(self) -> bool {
-        matches!(self, BumpLevel::Alpha | BumpLevel::Beta | BumpLevel::Rc)
-    }
-
     pub fn bump_version(
         self,
         version: &mut Version,
-        metadata: Option<&String>,
+        metadata: Option<&str>,
     ) -> Result<bool, FatalError> {
         let mut need_commit = false;
         match self {


### PR DESCRIPTION
Besides separating concerns, this is a step towards a potential solution
to #222, see discussion in #246.  Now we are preserving whether the user
used an absolute or relative version.