### PR TITLE
fix(git): respect 'disable_push' flag at package level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+* Respect `disable_push` flag at package level.
+
 ## [0.16.1] - 2021-07-04
 
-### Fixed 
+### Fixed
 
 * Submodule operation dir issue
 


### PR DESCRIPTION
This introduces an additional check for the 'disable_push' option
at the package level, to allow specific setting for a single entry.
The corresponding workspace option is still evaluated before this.

Closes: https://github.com/sunng87/cargo-release/issues/280