### PR TITLE
fix(bump): Ensure post-release dependents fixup works

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -193,13 +193,9 @@ impl<'m> PackageRelease<'m> {
             .as_ref()
             .map(Version::is_prerelease)
             .unwrap_or(false);
-        let dependents = if version.is_some() {
-            find_dependents(ws_meta, pkg_meta)
-                .map(|(pkg, dep)| Dependency { pkg, req: &dep.req })
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let dependents = find_dependents(ws_meta, pkg_meta)
+            .map(|(pkg, dep)| Dependency { pkg, req: &dep.req })
+            .collect();
 
         let base = version.as_ref().unwrap_or(&prev_version);
 


### PR DESCRIPTION
PR #209 made it so we update dependents on post-release bump, and not
just pre-release.  What was missed is an optimization, saving us from
looking up dependents when there is no version bump, causing us to do no
post-release dependents fix up.